### PR TITLE
Drop python 3.7 from the test matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate_matrix
         uses: coactions/dynamic-matrix@v1
         with:
-          min_python: "3.7"
+          min_python: "3.8"
           max_python: "3.12"
           default_python: "3.11" # used by jobs in other_names
           other_names: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["ansible", "collections", "tox"]
 license = { text = "MIT" }
 maintainers = [{ "name" = "Ansible by Red Hat", "email" = "info@ansible.com" }]
 authors = [{ "name" = "Bradley A. Thornton", "email" = "bthornto@redhat.com" }]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   'Development Status :: 2 - Pre-Alpha',
   'Intended Audience :: Developers',
@@ -26,7 +26,6 @@ classifiers = [
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
-  'Programming Language :: Python :: 3.7',
   'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Partially closes: https://github.com/ansible/tox-ansible/issues/236

There will be a follow-up PR to remove python 3.7 support from the src.