### PR TITLE
Drop ansible 2.9 testing within the plugin

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -40,7 +40,6 @@ ALLOWED_EXTERNALS = [
     "echo",
 ]
 ENV_LIST = """
-{integration, sanity, unit}-py3.7-2.9
 {integration, sanity, unit}-py3.8-{2.9, 2.12, 2.13}
 {integration, sanity, unit}-py3.9-{2.12, 2.13, 2.14, 2.15}
 {integration, sanity, unit}-py3.10-{2.12, 2.13, 2.14, 2.15, 2.16, milestone, devel}


### PR DESCRIPTION
Closes: https://github.com/ansible/tox-ansible/issues/237

Related: https://github.com/ansible/tox-ansible/issues/236

This change is being made to remove python 3.7 support from the src.