### PR TITLE
Include testing with python 3.12 in the plugin

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -45,6 +45,7 @@ ENV_LIST = """
 {integration, sanity, unit}-py3.9-{2.12, 2.13, 2.14, 2.15}
 {integration, sanity, unit}-py3.10-{2.12, 2.13, 2.14, 2.15, 2.16, milestone, devel}
 {integration, sanity, unit}-py3.11-{2.14, 2.15, 2.16, milestone, devel}
+{integration, sanity, unit}-py3.12-{2.16, milestone, devel}
 """
 TOX_WORK_DIR = Path()
 OUR_DEPS = [


### PR DESCRIPTION
Closes: https://github.com/ansible/tox-ansible/issues/235

This will introduce python 3.12 testing scenarios from the plugin.