### PR TITLE
Remove no-commit-to-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,6 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: end-of-file-fixer
-      - id: no-commit-to-branch
-        args: [--branch, main]
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/add-trailing-comma.git


### PR DESCRIPTION
Running no-commit-to-branch hooks prevents us from running on pushes and will break codecov from reporting on main branch.