### PR TITLE
Avoid stacktrace due to isinstance not allowing parametrized generics

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -62,7 +62,7 @@ class AnsibleConfigSet(ConfigSet):
         """Register the ansible configuration."""
         self.add_config(
             "skip",
-            of_type=List[str], # noqa: UP006 https://github.com/tox-dev/tox/issues/3287
+            of_type=List[str],  # noqa: UP006 https://github.com/tox-dev/tox/issues/3287
             default=[],
             desc="ansible configuration",
         )

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -12,7 +12,7 @@ import uuid
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar  # noqa: UP035
 
 import yaml
 
@@ -62,7 +62,7 @@ class AnsibleConfigSet(ConfigSet):
         """Register the ansible configuration."""
         self.add_config(
             "skip",
-            of_type=list[str],
+            of_type=List[str], # noqa: UP006 https://github.com/tox-dev/tox/issues/3287
             default=[],
             desc="ansible configuration",
         )


### PR DESCRIPTION
Using list[] is perfectly fine with recent version of python but this does break tox itself runtime type checking. This change should avoid the problem until we can change tox to also work with these.

Related: https://github.com/tox-dev/tox/issues/3287