### PR TITLE
Fix type issue with tox

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,6 +1,7 @@
 autouse
 basepython
 calver
+capsys
 cidrblock
 codecov
 delenv

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -12,7 +12,7 @@ import uuid
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar  # noqa: UP035
 
 import yaml
 
@@ -62,7 +62,7 @@ class AnsibleConfigSet(ConfigSet):
         """Register the ansible configuration."""
         self.add_config(
             "skip",
-            of_type=list[str],
+            of_type=List[str],  # noqa: UP006
             default=[],
             desc="ansible configuration",
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,18 @@ import pytest
 if TYPE_CHECKING:
     from _pytest.python import Metafunc
 
+GH_MATRIX_LENGTH = 36
+
+
+@pytest.fixture(scope="session")
+def matrix_length() -> int:
+    """Provide the length of the gh matrix.
+
+    Returns:
+        Length of the matrix
+    """
+    return GH_MATRIX_LENGTH
+
 
 @pytest.fixture(scope="module")
 def module_fixture_dir(request: pytest.FixtureRequest) -> Path:

--- a/tests/fixtures/unit/test_type/tox-ansible.ini
+++ b/tests/fixtures/unit/test_type/tox-ansible.ini
@@ -20,4 +20,4 @@ pass_env =
 
 [ansible]
 skip =
-    milestone
+    devel

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -43,15 +43,18 @@ def test_user_provided(
 
 
 def test_user_provided_matrix_success(
+    monkeypatch: pytest.MonkeyPatch,
     module_fixture_dir: Path,
     matrix_length: int,
 ) -> None:
     """Test supplemental user configuration for matrix generation.
 
     Args:
+        monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture for module fixture directory
         matrix_length: pytest fixture for matrix length
     """
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     proc = subprocess.run(
         f"tox --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
         capture_output=True,

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -1,5 +1,6 @@
 """User provided configuration."""
 
+import json
 import subprocess
 
 from configparser import ConfigParser
@@ -37,4 +38,31 @@ def test_user_provided(
         assert cfg_parser.get(env_name, "commands") == "root"
         assert cfg_parser.get(env_name, "deps") == "root"
         assert "root" in cfg_parser.get(env_name, "set_env")
+        assert "milestone" not in env_name
     assert "specific" in cfg_parser.get("testenv:integration-py3.11-devel", "pass_env")
+
+
+def test_user_provided_matrix_success(
+    module_fixture_dir: Path,
+    matrix_length: int,
+) -> None:
+    """Test supplemental user configuration for matrix generation.
+
+    Args:
+        module_fixture_dir: pytest fixture for module fixture directory
+        matrix_length: pytest fixture for matrix length
+    """
+    proc = subprocess.run(
+        f"tox config --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
+        capture_output=True,
+        cwd=str(module_fixture_dir),
+        text=True,
+        check=True,
+        shell=True,
+    )
+    matrix = json.loads(proc.stdout)
+    matrix_len = matrix_length
+    assert len(matrix) == matrix_len
+    for entry in matrix:
+        assert entry["description"]
+        assert entry["factors"]

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -53,7 +53,7 @@ def test_user_provided_matrix_success(
         matrix_length: pytest fixture for matrix length
     """
     proc = subprocess.run(
-        f"tox config --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
+        f"tox --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
         capture_output=True,
         cwd=str(module_fixture_dir),
         text=True,

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -55,6 +55,7 @@ def test_user_provided_matrix_success(
         matrix_length: pytest fixture for matrix length
     """
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     proc = subprocess.run(
         f"tox --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
         capture_output=True,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for tox-ansible."""

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -1,0 +1,86 @@
+"""Test the use of a generic type with tox.
+
+These are specific to PR https://github.com/tox-dev/tox/pull/3288
+
+At that time the 2nd test can be switched to a SystemExit like test #1
+The types override for List/list and the related ruff noqa's in plugin.py can be removed.
+"""
+
+import json
+import runpy
+
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+from tox.config.sets import ConfigSet
+
+
+def test_type_current(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    module_fixture_dir: Path,
+    matrix_length: int,
+) -> None:
+    """Test the current runtime for a gh matrix.
+
+    Args:
+        capsys: pytest fixture to capture stdout and stderr
+        monkeypatch: pytest fixture to patch modules
+        module_fixture_dir: pytest fixture to provide a module specific fixture directory
+        matrix_length: pytest fixture to provide the length of the gh matrix
+    """
+    monkeypatch.chdir(module_fixture_dir)
+    args = [
+        "--ansible",
+        "--gh-matrix",
+        "--conf",
+        "tox-ansible.ini",
+    ]
+    out = runpy.run_module("tox")
+    with pytest.raises(SystemExit):
+        out["run"](args=args)
+    captured = capsys.readouterr()
+    matrix = json.loads(captured.out)
+    matrix_len = matrix_length
+    assert len(matrix) == matrix_len
+    for entry in matrix:
+        assert entry["description"]
+        assert entry["factors"]
+
+
+def test_type_broken(
+    monkeypatch: pytest.MonkeyPatch,
+    module_fixture_dir: Path,
+) -> None:
+    """Test the current runtime for a gh matrix.
+
+    Args:
+        monkeypatch: pytest fixture to patch modules
+        module_fixture_dir: pytest fixture to provide a module specific fixture directory
+    """
+    T = TypeVar("T", bound=ConfigSet)
+
+    def register_config(self: T) -> None:
+        """Register the ansible configuration."""
+        self.add_config(
+            "skip",
+            of_type=list[str],
+            default=[],
+            desc="ansible configuration",
+        )
+
+    monkeypatch.setattr("tox_ansible.plugin.AnsibleConfigSet.register_config", register_config)
+    monkeypatch.chdir(module_fixture_dir)
+    args = [
+        "--ansible",
+        "--gh-matrix",
+        "--conf",
+        "tox-ansible.ini",
+    ]
+    out = runpy.run_module("tox")
+    match = "isinstance() argument 2 cannot be a parameterized generic"
+    with pytest.raises(TypeError) as exc:
+        out["run"](args=args)
+    assert str(exc.value) == match

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -63,7 +63,11 @@ def test_type_broken(
     T = TypeVar("T", bound=ConfigSet)
 
     def register_config(self: T) -> None:
-        """Register the ansible configuration."""
+        """Register the ansible configuration.
+
+        Args:
+            self: the current instance
+        """
         self.add_config(
             "skip",
             of_type=list[str],

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -18,7 +18,7 @@ from tox.config.sets import ConfigSet
 
 
 def test_type_current(
-    capsys: pytest.CaptureFixture,
+    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
     module_fixture_dir: Path,
     matrix_length: int,
@@ -31,6 +31,8 @@ def test_type_current(
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
         matrix_length: pytest fixture to provide the length of the gh matrix
     """
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)
     args = [
         "--ansible",

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -2,7 +2,7 @@
 
 These are specific to PR https://github.com/tox-dev/tox/pull/3288
 
-At that time the 2nd test can be switched to a SystemExit like test #1
+When merged the 2nd test can be switched to a SystemExit like test #1
 The types override for List/list and the related ruff noqa's in plugin.py can be removed.
 """
 


### PR DESCRIPTION
This is a work around for a ruff fix to generic types and tox.

Also added is a gh matrix generation test with a custom config and `[ansible]` section which would have caught the error earlier.

Related: https://github.com/tox-dev/tox/issues/3287
Related: https://github.com/tox-dev/tox/pull/3288
Closes: #296 