### PR TITLE
Collect coverage for subprocess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ line-length = 100
 
 [tool.coverage.report]
 exclude_lines = ["if TYPE_CHECKING:", "pragma: no cover"]
-fail_under = 21
+fail_under = 75
 ignore_errors = true
 show_missing = true
 skip_covered = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,16 @@ GH_MATRIX_LENGTH = 36
 
 
 @pytest.fixture(scope="session")
+def tox_bin() -> Path:
+    """Provide the path to the tox binary.
+
+    Returns:
+        Path to the tox binary
+    """
+    return Path(sys.executable).parent / "tox"
+
+
+@pytest.fixture(scope="session")
 def matrix_length() -> int:
     """Provide the length of the gh matrix.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,20 @@
-"""Global testing fixtures."""
+"""Global testing fixtures.
+
+The root package import below happens before the pytest workers are forked, so it
+picked up by the initial coverage process for a source match.
+
+Without it, coverage reports the following false positive error:
+
+CoverageWarning: No data was collected. (no-data-collected)
+
+This works in conjunction with the coverage source_pkg set to the package such that
+a `coverage run --debug trace` shows the source package and file match.
+
+<...>
+Imported source package '<package>' as '/**/src/<package>/__init__.py'
+<...>
+Tracing '/**/src/<package>/__init__.py'
+"""
 
 from __future__ import annotations
 
@@ -12,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+import tox_ansible  # noqa: F401
 
 
 if TYPE_CHECKING:

--- a/tests/fixtures/integration/test_basic/tox-ansible.ini
+++ b/tests/fixtures/integration/test_basic/tox-ansible.ini
@@ -1,3 +1,4 @@
 [tox]
 requires =
     tox>=4.2
+

--- a/tests/fixtures/integration/test_basic/tox-ansible.ini
+++ b/tests/fixtures/integration/test_basic/tox-ansible.ini
@@ -1,4 +1,3 @@
 [tox]
 requires =
     tox>=4.2
-

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tox_ansible.plugin import conf_passenv
-
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -104,9 +102,3 @@ def test_environment_config(
 
     assert "https://github.com/ansible/ansible/archive" in config["deps"]
     assert "XDG_CACHE_HOME" in config["set_env"]
-
-
-def test_import() -> None:
-    """Verify that module can be imported (used for coverage)."""
-    x = conf_passenv()
-    assert "GITHUB_TOKEN" in x

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -1,6 +1,7 @@
 """User provided configuration."""
 
 import json
+import os
 import subprocess
 
 from configparser import ConfigParser
@@ -11,20 +12,23 @@ import pytest
 
 def test_user_provided(
     module_fixture_dir: Path,
+    tox_bin: Path,
 ) -> None:
     """Test supplemental user configuration.
 
     Args:
         module_fixture_dir: pytest fixture for module fixture directory
+        tox_bin: pytest fixture for tox binary
     """
     try:
         proc = subprocess.run(
-            f"tox config --ansible --root {module_fixture_dir} --conf tox-ansible.ini",
+            f"{tox_bin} config --ansible --root {module_fixture_dir} --conf tox-ansible.ini",
             capture_output=True,
             cwd=str(module_fixture_dir),
             text=True,
             check=True,
             shell=True,
+            env=os.environ,
         )
     except subprocess.CalledProcessError as exc:
         print(exc.stdout)
@@ -43,26 +47,29 @@ def test_user_provided(
 
 
 def test_user_provided_matrix_success(
-    monkeypatch: pytest.MonkeyPatch,
-    module_fixture_dir: Path,
     matrix_length: int,
+    module_fixture_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tox_bin: Path,
 ) -> None:
     """Test supplemental user configuration for matrix generation.
 
     Args:
-        monkeypatch: pytest fixture to patch modules
-        module_fixture_dir: pytest fixture for module fixture directory
         matrix_length: pytest fixture for matrix length
+        module_fixture_dir: pytest fixture for module fixture directory
+        monkeypatch: pytest fixture to patch modules
+        tox_bin: pytest fixture for tox binary
     """
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     proc = subprocess.run(
-        f"tox --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
+        f"{tox_bin} --ansible --root {module_fixture_dir} --gh-matrix --conf tox-ansible.ini",
         capture_output=True,
         cwd=str(module_fixture_dir),
         text=True,
         check=True,
         shell=True,
+        env=os.environ,
     )
     matrix = json.loads(proc.stdout)
     matrix_len = matrix_length

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ env_list =
     pkg
     docs
 skip_missing_interpreters = true
-work_dir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 description = Run pytest under {basepython}


### PR DESCRIPTION
In the end, the `workdir` setting in the `tox.ini` was a relative directory which was causing the `envdir` to be relative, which was causing the `COVERAGE_*` environment variables to be relative, which resulted in the coverage files being written into the fixture directories.

We'll pass the environment to the subprocess to preserve the coverage environment variables now.

The bin for tox will now will be adjacent to the python interpreter to ensure the `coverage.pth` file written in the `tox.ini` file is picked up.

Additionally, the project import was moved out of the tests into the conftest.py with an explanation for it's existence.