### PR TITLE
chore: Update .github/workflows/push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ on:
       - main
       - "releases/**"
       - "stable/**"
+  workflow_dispatch:
 
 jobs:
   ack:


### PR DESCRIPTION
Allow manually running push for release note generation after a failed or reverted release.
