### PR TITLE
Add pip upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ line-length = 100
 
 [tool.coverage.report]
 exclude_also = ["if TYPE_CHECKING:", "pragma: no cover"]
-fail_under = 75
+fail_under = 82
 ignore_errors = true
 show_missing = true
 skip_covered = true

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -449,7 +449,7 @@ def conf_commands_for_sanity(
     return commands
 
 
-def conf_commands_pre(
+def conf_commands_pre(  # noqa: C901
     env_conf: EnvConfigSet,
     c_name: str,
     c_namespace: str,
@@ -472,6 +472,13 @@ def conf_commands_pre(
     collection_installed_at = f"{collections_root}/ansible_collections/{c_namespace}/{c_name}"
     galaxy_build_dir = f"{envtmpdir}/collection_build"
     end_group = "echo ::endgroup::"
+
+    if in_action():
+        group = "echo ::group::Ensure pip is up to date"
+        commands.append(group)
+    commands.append("python -m ensurepip --upgrade")
+    if in_action():
+        commands.append(end_group)
 
     if in_action():
         group = "echo ::group::Make the galaxy build dir"

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,0 +1,42 @@
+"""Unit plugin tests."""
+
+from pathlib import Path
+
+import pytest
+
+from tox.config.cli.parser import Parsed
+from tox.config.main import Config
+from tox.config.source import discover_source
+
+from tox_ansible.plugin import conf_commands_pre
+
+
+def test_commands_pre(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test pre-command generation.
+
+    Args:
+        monkeypatch: Pytest fixture.
+        tmp_path: Pytest fixture.
+    """
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+    ).get_env("py39")
+
+    conf.add_config(
+        keys=["env_tmp_dir", "envtmpdir"],
+        of_type=Path,
+        default=tmp_path,
+        desc="",
+    )
+
+    result = conf_commands_pre(env_conf=conf, c_name="test", c_namespace="test")
+    number_commands = 15
+    assert len(result) == number_commands, result


### PR DESCRIPTION
Add a command as a pre command to ensure pip is up todate.

This should help avoid ```AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?``` when an older version of pip is used with python 3.12.

When tox is running from a python3.11 interpreter, the python3.11 wheel for pip is used even when setting up a virtual environment fro python3.12.  This introduces a version that is broken with python3.12.

So, we'll just make sure pip is current as a precommand which should resolve the issue

