### PR TITLE
Revert pip upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ line-length = 100
 
 [tool.coverage.report]
 exclude_also = ["if TYPE_CHECKING:", "pragma: no cover"]
-fail_under = 82
+fail_under = 81
 ignore_errors = true
 show_missing = true
 skip_covered = true

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -449,7 +449,7 @@ def conf_commands_for_sanity(
     return commands
 
 
-def conf_commands_pre(  # noqa: C901
+def conf_commands_pre(
     env_conf: EnvConfigSet,
     c_name: str,
     c_namespace: str,
@@ -472,13 +472,6 @@ def conf_commands_pre(  # noqa: C901
     collection_installed_at = f"{collections_root}/ansible_collections/{c_namespace}/{c_name}"
     galaxy_build_dir = f"{envtmpdir}/collection_build"
     end_group = "echo ::endgroup::"
-
-    if in_action():
-        group = "echo ::group::Ensure pip is up to date"
-        commands.append(group)
-    commands.append("python -m ensurepip --upgrade")
-    if in_action():
-        commands.append(end_group)
 
     if in_action():
         group = "echo ::group::Make the galaxy build dir"

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -38,5 +38,5 @@ def test_commands_pre(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     )
 
     result = conf_commands_pre(env_conf=conf, c_name="test", c_namespace="test")
-    number_commands = 15
+    number_commands = 12
     assert len(result) == number_commands, result


### PR DESCRIPTION
This reverts #333.  `commands_pre` runs after the `deps` are installed and the `deps` require a current version of `pip`.

tos facilitates this already, (TIL).  It has the ability to download `pip` rather than use the wheel.

`tox-ansible.ini`

```ini
[testenv]
download = true
```
is all that is needed. 

example
```
integration-py3.12-2.16: 10494 D download wheel pip 3.12 to /root/.local/share/virtualenv/wheel/house [virtualenv/seed/wheels/acquire.py:53]
```