### PR TITLE
Exclude *-py3.10-devel from matrix

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -41,7 +41,7 @@ ALLOWED_EXTERNALS = [
 ]
 ENV_LIST = """
 {integration, sanity, unit}-py3.9-{2.15}
-{integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17, milestone, devel}
+{integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17, milestone}
 {integration, sanity, unit}-py3.11-{2.15, 2.16, 2.17, milestone, devel}
 {integration, sanity, unit}-py3.12-{2.16, 2.17, milestone, devel}
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ import tox_ansible  # noqa: F401
 if TYPE_CHECKING:
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 36
+GH_MATRIX_LENGTH = 33
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -25,7 +25,6 @@ def test_type_current(
         capsys: pytest fixture to capture stdout and stderr
         monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
-        matrix_length: pytest fixture to provide the length of the gh matrix
     """
     matrix_length = 36
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -18,7 +18,6 @@ def test_type_current(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
     module_fixture_dir: Path,
-    matrix_length: int,
 ) -> None:
     """Test the current runtime for a gh matrix.
 
@@ -28,6 +27,7 @@ def test_type_current(
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
         matrix_length: pytest fixture to provide the length of the gh matrix
     """
+    matrix_length = 36
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)
@@ -42,8 +42,7 @@ def test_type_current(
         out["run"](args=args)
     captured = capsys.readouterr()
     matrix = json.loads(captured.out)
-    matrix_len = matrix_length
-    assert len(matrix) == matrix_len
+    assert len(matrix) == matrix_length
     for entry in matrix:
         assert entry["description"]
         assert entry["factors"]


### PR DESCRIPTION
Required due to: https://github.com/ansible/ansible/blob/devel/setup.cfg#L39