### PR TITLE
Drop 3.10 devel

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -41,7 +41,7 @@ ALLOWED_EXTERNALS = [
 ]
 ENV_LIST = """
 {integration, sanity, unit}-py3.9-{2.15}
-{integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17, milestone}
+{integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17}
 {integration, sanity, unit}-py3.11-{2.15, 2.16, 2.17, milestone, devel}
 {integration, sanity, unit}-py3.12-{2.16, 2.17, milestone, devel}
 """


### PR DESCRIPTION
Since milestone will cut from devel and devel is 2.18 and won't support 3.10, we'll drop 3.10 milestone now.

Realted: #336 