### PR TITLE
chore: Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ allow-init-docstring = true
 arg-type-hints-in-docstring = false
 baseline = ".config/pydoclint-baseline.txt"
 check-return-types = false
-exclude = '.eggs|\.git|\.tox|build|out|venv'
+exclude = '\.git|\.tox|build|out|venv'
 show-filenames-in-every-violation-message = true
 skip-checking-short-docstrings = false
 style = "google"
@@ -342,6 +342,7 @@ parametrize-values-type = "tuple"
 known-first-party = ["tox_ansible"]
 lines-after-imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
 lines-between-types = 1 # Separate import/from with 1 line
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
 "_version.py" = ["SIM108"]

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -1,4 +1,5 @@
 """User provided configuration."""
+
 from __future__ import annotations
 
 import json
@@ -6,9 +7,13 @@ import os
 import subprocess
 
 from configparser import ConfigParser
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_user_provided(

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -1,4 +1,5 @@
 """User provided configuration."""
+from __future__ import annotations
 
 import json
 import os

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,4 +1,5 @@
 """Unit plugin tests."""
+
 from __future__ import annotations
 
 import io

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,4 +1,5 @@
 """Unit plugin tests."""
+from __future__ import annotations
 
 import io
 import json

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -5,6 +5,7 @@ These are specific to PR https://github.com/tox-dev/tox/pull/3288
 When merged the 2nd test can be switched to a SystemExit like test #1
 The types override for List/list and the related ruff noqa's in plugin.py can be removed.
 """
+from __future__ import annotations
 
 import json
 import runpy

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -5,14 +5,19 @@ These are specific to PR https://github.com/tox-dev/tox/pull/3288
 When merged the 2nd test can be switched to a SystemExit like test #1
 The types override for List/list and the related ruff noqa's in plugin.py can be removed.
 """
+
 from __future__ import annotations
 
 import json
 import runpy
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_type_current(


### PR DESCRIPTION
Allow ruff to add future annotations

Note: This PR has some failed checks because the tox-ansible workflow was enabled and is not intended to run for PRs.  It is a reusable workflow to be used from other repositories.
