### PR TITLE
Docsite: add communication info

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ By using `tox` to create and manage the testing environments, Test outcomes shou
 
 `tox` virtual environments are created in the `.tox` directory. These are easily deleted and recreated if needed.
 
+## Talk to us
+
+Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+
 ## Installation
 
 Install from pypi:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By using `tox` to create and manage the testing environments, Test outcomes shou
 
 ## Talk to us
 
-Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) join the conversation!
 
 ## Installation
 

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -26,25 +26,30 @@ Prerequisites:
 Feel free to raise issues in the repo if you feel unable to contribute a code
 fix.
 
+Possible security bugs should be reported via email to <mailto:security@ansible.com>.
+
 ## Talk to us
 
-Use Github [discussions] forum or for a live chat experience try
-`#ansible-devtools` IRC channel on libera.chat or Matrix room
-[#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com).
+### Code of Conduct
 
-For the full list of Ansible IRC and Mailing list, please see the [Ansible
-Communication] page. Release announcements will be made to the [Ansible
-Announce] list.
+Please read and adhere to the [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) in all your interactions within the Ansible community.
 
-Possible security bugs should be reported via email to
-<mailto:security@ansible.com>.
+### Forum
 
-## Code of Conduct
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-Please see the official [Ansible Community Code of Conduct].
+* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `devtools`.
+* [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
+* [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn) used to announce releases and important changes.
+* [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-[discussions]: https://github.com/ansible/tox-ansible/discussions
-[ansible communication]: https://docs.ansible.com/ansible/latest/community/communication.html
-[ansible announce]: https://groups.google.com/forum/#!forum/ansible-announce
-[Ansible Community Code of Conduct]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
+For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+
+### Matrix
+
+For real-time interactions, conversations in the community happen over the Matrix protocol in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com).
+
+For more information, see the community-hosted [Matrix FAQ](https://hackmd.io/@ansible-community/community-matrix-faq).
+
 [creating your fork on github]: https://docs.github.com/en/get-started/quickstart/contributing-to-projects

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -32,7 +32,7 @@ Possible security bugs should be reported via email to <mailto:security@ansible.
 
 ### Code of Conduct
 
-Please read and adhere to the [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) in all your interactions within the Ansible community.
+Please read and adhere to the [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) in all your interactions with the Ansible community.
 
 ### Forum
 

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -44,7 +44,7 @@ Join the [Ansible Forum](https://forum.ansible.com) as a single starting point a
 - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
 - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
 
 ### Matrix
 

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -44,7 +44,7 @@ Join the [Ansible Forum](https://forum.ansible.com) as a single starting point a
 - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
 - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`\_ for some practical advice on finding your way around.
 
 ### Matrix
 

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -38,11 +38,11 @@ Please read and adhere to the [Ansible Community Code of Conduct](https://docs.a
 
 Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `devtools`.
-* [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
-* [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn) used to announce releases and important changes.
-* [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `devtools`.
+- [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
+- [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn) used to announce releases and important changes.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
 For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,7 @@
 # Frequently asked questions
 
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+
 ## How does it work?
 
 `tox` will, by default, create a Python virtual environment for a given environment. `tox-ansible` adds Ansible collection specific build and test logic to tox. The collection is copied into the virtual environment created by tox, built, and installed into the virtual environment. The installation of the collection will include the collection's collection dependencies. `tox-ansible` will also install any Python dependencies from a `test-requirements.txt` (or `requirements-test.txt`) and `requirements.txt` file. The virtual environment's temporary directory is used, so the copy, build and install steps are performed with each test run ensuring the current collection code is used.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently asked questions
 
-> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) join the conversation!
 
 ## How does it work?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Tox Ansible Documentation
 
-> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to join the conversation!
 
 ## About Tox Ansible
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Tox Ansible Documentation
 
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+
 ## About Tox Ansible
 
 `tox-ansible` is a utility designed to simplify the testing of ansible content collections.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+
 Getting started with tox-ansible is as simple as:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to join the conversation!
 
 Getting started with tox-ansible is as simple as:
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,5 +1,7 @@
 # Usage of tox-ansible
 
+> Need help or want to discuss the project? See our [Contributor guide](https://ansible.readthedocs.io/projects/tox-ansible/contributor_guide/#talk-to-us) to learn how to join the conversation!
+
 From the root of your collection, create an empty `tox-ansible.ini` file and list the available environments:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/tox-ansible/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/tox-ansible
       name: GitHub


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you