### PR TITLE
Add support for py313 and ansible 2.18

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,3 +17,6 @@ concurrency:
 jobs:
   tox:
     uses: ansible/team-devtools/.github/workflows/tox.yml@main
+    with:
+      max_python: "3.13"
+      jobs_producing_coverage: 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
   'Programming Language :: Python :: Implementation :: CPython',
   'Programming Language :: Python :: Implementation :: PyPy'
 ]

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -42,8 +42,9 @@ ALLOWED_EXTERNALS = [
 ENV_LIST = """
 {integration, sanity, unit}-py3.9-{2.15}
 {integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17}
-{integration, sanity, unit}-py3.11-{2.15, 2.16, 2.17, milestone, devel}
-{integration, sanity, unit}-py3.12-{2.16, 2.17, milestone, devel}
+{integration, sanity, unit}-py3.11-{2.15, 2.16, 2.17, 2.18, milestone, devel}
+{integration, sanity, unit}-py3.12-{2.16, 2.17, 2.18, milestone, devel}
+{integration, sanity, unit}-py3.13-{2.18, milestone, devel}
 """
 TOX_WORK_DIR = Path()
 OUR_DEPS = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ import tox_ansible  # noqa: F401
 if TYPE_CHECKING:
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 33
+GH_MATRIX_LENGTH = 45
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -32,7 +32,7 @@ def test_type_current(
         monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
     """
-    matrix_length = 33
+    matrix_length = 45
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)


### PR DESCRIPTION
Please note that this increase the size of the default test matrix from 33 to 45.
Closes: #384 
Related: https://github.com/ansible/team-devtools/issues/229