### PR TITLE
Replace cp --parents with bash script for macOS compatibility

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 ALLOWED_EXTERNALS = [
     "bash",
+    "sh",
     "cp",
     "git",
     "rm",
@@ -526,7 +527,7 @@ def conf_commands_pre(
         f"cp -r $file {galaxy_build_dir}/$file;\n"
         "done"
     )
-    full_cmd = f"bash -c '{cd_tox_dir} && {copy_script}'"
+    full_cmd = f"sh -c '{cd_tox_dir} && {copy_script}'"
     commands.append(full_cmd)
     if in_action():
         commands.append(end_group)

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -38,6 +38,7 @@ ALLOWED_EXTERNALS = [
     "mkdir",
     "cd",
     "echo",
+    "dirname",
 ]
 ENV_LIST = """
 {integration, sanity, unit}-py3.9-{2.15}
@@ -518,8 +519,13 @@ def conf_commands_pre(
         group = "echo ::group::Copy the collection to the galaxy build dir"
         commands.append(group)
     cd_tox_dir = f"cd {TOX_WORK_DIR}"
-    copy_cmd = f"cp -r --parents $(git ls-files 2> /dev/null || ls) {galaxy_build_dir}"
-    full_cmd = f"bash -c '{cd_tox_dir} && {copy_cmd}'"
+    copy_script = (
+        f"for file in $(git ls-files 2> /dev/null || ls); do\n\t"
+        f"mkdir -p {galaxy_build_dir}/$(dirname $file);\n\t"
+        f"cp -r $file {galaxy_build_dir}/$file;\n"
+        "done"
+    )
+    full_cmd = f"bash -c '{cd_tox_dir} && {copy_script}'"
     commands.append(full_cmd)
     if in_action():
         commands.append(end_group)


### PR DESCRIPTION
**Resolves #246**

### Summary
Replaced the use of `cp --parents` with bash scripting to ensure compatibility with macOS.

### Details
To verify this change, I ran a minimal example:

- Test run on `macos-latest` and `ubuntu-latest`: [GitHub Action run](https://github.com/abhikdps/tox-ansible/actions/runs/11724935655/job/32660016267)

#### Note
The test setup intentionally causes all **integration tests to fail** while ensuring **unit tests succeed**. This confirms that the tests are executing correctly as expected.

#### Original Contribution
https://github.com/ansible/tox-ansible/pull/379 by [h3nryc0ding](https://github.com/h3nryc0ding)