### PR TITLE
Remove support for ansible-core 2.15 due EOL

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -114,7 +114,7 @@ The arguments after the `--` will be passed to the `ansible-test` command. Thus 
 Same can be done to pass arguments to the `pytest` commands for the `unit-*` and `integration-*` environments:
 
 ```bash
-tox -e unit-py3.11-2.15 --ansible --conf tox-ansible.ini -- --junit-xml=tests/output/junit/unit.xml
+tox -e unit-py3.13-2.18 --ansible --conf tox-ansible.ini -- --junit-xml=tests/output/junit/unit.xml
 ```
 
 ## Usage in a CI/CD pipeline

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -42,9 +42,8 @@ ALLOWED_EXTERNALS = [
     "dirname",
 ]
 ENV_LIST = """
-{integration, sanity, unit}-py3.9-{2.15}
-{integration, sanity, unit}-py3.10-{2.15, 2.16, 2.17}
-{integration, sanity, unit}-py3.11-{2.15, 2.16, 2.17, 2.18, milestone, devel}
+{integration, sanity, unit}-py3.10-{2.16, 2.17}
+{integration, sanity, unit}-py3.11-{2.16, 2.17, 2.18, milestone, devel}
 {integration, sanity, unit}-py3.12-{2.16, 2.17, 2.18, milestone, devel}
 {integration, sanity, unit}-py3.13-{2.18, milestone, devel}
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 45
+GH_MATRIX_LENGTH = 36
 
 
 def run(

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -67,7 +67,7 @@ def test_check_num_candidates_2(caplog: pytest.LogCaptureFixture) -> None:
     Args:
         caplog: Pytest fixture.
     """
-    environment_list = EnvList(envs=["integration-py3.9-py3.9"])
+    environment_list = EnvList(envs=["integration-py3.13-py3.13"])
     with pytest.raises(SystemExit, match="1"):
         generate_gh_matrix(environment_list, "all")
     logs = caplog.text
@@ -96,7 +96,8 @@ def test_gen_version_matrix(python: str, tmp_path: Path, monkeypatch: pytest.Mon
         tmp_path: Pytest fixture.
         monkeypatch: Pytest fixture.
     """
-    environment_list = EnvList(envs=[f"integration-{python}-2.15"])
+    av = "2.18"
+    environment_list = EnvList(envs=[f"integration-{python}-{av}"])
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
     gh_output = tmp_path / "matrix.json"
     monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
@@ -106,9 +107,9 @@ def test_gen_version_matrix(python: str, tmp_path: Path, monkeypatch: pytest.Mon
     assert json_string
     json_result = json.loads(json_string.group("json"))
     assert json_result[0] == {
-        "description": f"Integration tests using ansible-core 2.15 and python {python[2:]}",
-        "factors": ["integration", python, "2.15"],
-        "name": f"integration-{python}-2.15",
+        "description": f"Integration tests using ansible-core {av} and python {python[2:]}",
+        "factors": ["integration", python, av],
+        "name": f"integration-{python}-{av}",
         "python": "3.13",
     }
 

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -32,7 +32,7 @@ def test_type_current(
         monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
     """
-    matrix_length = 45
+    matrix_length = 36
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)


### PR DESCRIPTION
As ansible-core passed EOL, we removed it from the test matrix.
This reduces the size of the default test matrix from 45 to 36.
