### PR TITLE
Remove support for ansible-core 2.16 due to EOL

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -43,9 +43,9 @@ ALLOWED_EXTERNALS = [
     "dirname",
 ]
 ENV_LIST = """
-{integration, sanity, unit}-py3.10-{2.16, 2.17}
-{integration, sanity, unit}-py3.11-{2.16, 2.17, 2.18, milestone, devel}
-{integration, sanity, unit}-py3.12-{2.16, 2.17, 2.18, milestone, devel}
+{integration, sanity, unit}-py3.10-{2.17}
+{integration, sanity, unit}-py3.11-{2.17, 2.18, milestone, devel}
+{integration, sanity, unit}-py3.12-{2.17, 2.18, milestone, devel}
 {integration, sanity, unit}-py3.13-{2.18, milestone, devel}
 """
 TOX_WORK_DIR = Path()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 36
+GH_MATRIX_LENGTH = 27
 
 
 def run(

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -32,7 +32,7 @@ def test_type_current(
         monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
     """
-    matrix_length = 36
+    matrix_length = 27
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)


### PR DESCRIPTION
### SUMMARY

As ansible-core 2.16 reaches end-of-life in May 2025, this PR removes it from the test matrix.

- This change reduces the default test matrix size from 36 to 27.
- Fixes the CI [failure](https://github.com/ansible/tox-ansible/actions/runs/15251192091/job/42888527900?pr=446#step:9:113) occurring in other open PRs (ansible-core 2.16 sanity tests)

For more details, refer to the [Ansible Core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).