### PR TITLE
Disable use of constraints for galaxy environment

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -677,4 +677,9 @@ def conf_setenv(env_conf: EnvConfigSet) -> str:
         f"{envvar_name}={envtmpdir}/collections/",
         f"XDG_CACHE_HOME={env_conf['env_dir']}/.cache",
     ]
+    # due to the ceilings used by galaxy-importer, use of constraints will
+    # likely cause installation failures.
+    if env_conf.name == "galaxy":
+        setenv.append("PIP_CONSTRAINT=/dev/null")
+        setenv.append("UV_CONSTRAINT=/dev/null")
     return "\n".join(setenv)


### PR DESCRIPTION
Prevents failure to install or installation of ancient version due to
presence of ceilings in galaxy-importer package.

Related: https://issues.redhat.com/browse/AAP-49207
