### PR TITLE
Remove py3.11 tests with ansible-core milestone branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,12 @@ default environments:
 ...
 integration-py3.11-2.14      -> Integration tests for ansible.scm using ansible-core 2.14 and python 3.11
 integration-py3.12-devel     -> Integration tests for ansible.scm using ansible-core devel and python 3.11
-integration-py3.11-milestone -> Integration tests for ansible.scm using ansible-core milestone and python 3.11
 ...
 sanity-py3.11-2.14           -> Sanity tests for ansible.scm using ansible-core 2.14 and python 3.11
 sanity-py3.12-devel          -> Sanity tests for ansible.scm using ansible-core devel and python 3.11
-sanity-py3.11-milestone      -> Sanity tests for ansible.scm using ansible-core milestone and python 3.11
 ...
 unit-py3.11-2.14             -> Unit tests for ansible.scm using ansible-core 2.14 and python 3.11
 unit-py3.12-devel            -> Unit tests for ansible.scm using ansible-core devel and python 3.11
-unit-py3.11-milestone        -> Unit tests for ansible.scm using ansible-core milestone and python 3.11
 ```
 
 These represent the available testing environments. Each denotes the type of tests that will be run, the Python interpreter used to run the tests, and the Ansible version used to run the tests.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -17,15 +17,12 @@ default environments:
 ...
 integration-py3.11-2.14      -> Integration tests for ansible.scm using ansible-core 2.14 and python 3.11
 integration-py3.12-devel     -> Integration tests for ansible.scm using ansible-core devel and python 3.11
-integration-py3.11-milestone -> Integration tests for ansible.scm using ansible-core milestone and python 3.11
 ...
 sanity-py3.11-2.14           -> Sanity tests for ansible.scm using ansible-core 2.14 and python 3.11
 sanity-py3.12-devel          -> Sanity tests for ansible.scm using ansible-core devel and python 3.11
-sanity-py3.11-milestone      -> Sanity tests for ansible.scm using ansible-core milestone and python 3.11
 ...
 unit-py3.11-2.14             -> Unit tests for ansible.scm using ansible-core 2.14 and python 3.11
 unit-py3.12-devel            -> Unit tests for ansible.scm using ansible-core devel and python 3.11
-unit-py3.11-milestone        -> Unit tests for ansible.scm using ansible-core milestone and python 3.11
 ```
 
 These represent the available testing environments. Each denotes the type of tests that will be run, the Python interpreter used to run the tests, and the Ansible version used to run the tests.

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -45,7 +45,7 @@ ALLOWED_EXTERNALS = [
 ENV_LIST = """
 galaxy
 {integration, sanity, unit}-py3.10-{2.17}
-{integration, sanity, unit}-py3.11-{2.17, 2.18, 2.19, milestone}
+{integration, sanity, unit}-py3.11-{2.17, 2.18, 2.19}
 {integration, sanity, unit}-py3.12-{2.17, 2.18, 2.19, milestone, devel}
 {integration, sanity, unit}-py3.13-{2.18, 2.19, milestone, devel}
 """

--- a/tests/unit/test_type.py
+++ b/tests/unit/test_type.py
@@ -32,7 +32,7 @@ def test_type_current(
         monkeypatch: pytest fixture to patch modules
         module_fixture_dir: pytest fixture to provide a module specific fixture directory
     """
-    matrix_length = 37
+    matrix_length = 34
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     monkeypatch.chdir(module_fixture_dir)


### PR DESCRIPTION
The ansible-core milestone branch requires python >=3.12 now.

https://github.com/ansible/ansible/blob/milestone/pyproject.toml#L6