### PR TITLE
feat: add stable-2.21 to the test matrix

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -48,9 +48,9 @@ ENV_LIST = """
 galaxy
 {integration, sanity, unit}-py3.10-{2.16, 2.17}
 {integration, sanity, unit}-py3.11-{2.17, 2.18, 2.19}
-{integration, sanity, unit}-py3.12-{2.17, 2.18, 2.19, 2.20, milestone, devel}
-{integration, sanity, unit}-py3.13-{2.18, 2.19, 2.20, milestone, devel}
-{integration, sanity, unit}-py3.14-{2.20, 2.20, milestone, devel}
+{integration, sanity, unit}-py3.12-{2.17, 2.18, 2.19, 2.20, 2.21, milestone, devel}
+{integration, sanity, unit}-py3.13-{2.18, 2.19, 2.20, 2.21, milestone, devel}
+{integration, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
 """
 # ^ py314 is NOT supported before 2.20! If is in official metadata of the
 # release branch, is not supported.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 49
+GH_MATRIX_LENGTH = 58
 
 
 def run(  # noqa: PLR0913


### PR DESCRIPTION
## Summary
- Add ansible-core `stable-2.21` to the test matrix for Python 3.12, 3.13, and 3.14 (matching [upstream support](https://github.com/ansible/ansible/blob/stable-2.21/pyproject.toml))
- Fix duplicate `2.20` entry on the `py3.14` line in `ENV_LIST`
- Update `GH_MATRIX_LENGTH` from 49 to 58

Fixes: AAP-71686

## Test plan
- [x] Unit tests pass (`pytest tests/unit -v` — 33/33 passed)
- [ ] Integration tests pass in CI
- [ ] Lint passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)