### PR TITLE
feat: add molecule as dependency for integration tests

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -675,6 +675,8 @@ def conf_deps(env_conf: EnvConfigSet, test_type: str) -> str:  # noqa: ARG001
         deps.append("ansible-dev-environment>=26.2.0")
         if test_type in ("integration", "unit"):
             deps.extend(OUR_DEPS)
+            if test_type == "integration":
+                deps.append("molecule>=26.4.0")
             try:
                 with (cwd / "test-requirements.txt").open() as fileh:
                     deps.extend(fileh.read().splitlines())

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -677,21 +677,12 @@ def conf_deps(env_conf: EnvConfigSet, test_type: str) -> str:  # noqa: ARG001
             deps.extend(OUR_DEPS)
             if test_type == "integration":
                 deps.append("molecule>=26.4.0")
-            try:
-                with (cwd / "test-requirements.txt").open() as fileh:
-                    deps.extend(fileh.read().splitlines())
-            except FileNotFoundError:
-                pass
-            try:
-                with (cwd / "requirements-test.txt").open() as fileh:
-                    deps.extend(fileh.read().splitlines())
-            except FileNotFoundError:
-                pass
-            try:
-                with (cwd / "requirements.txt").open() as fileh:
-                    deps.extend(fileh.read().splitlines())
-            except FileNotFoundError:
-                pass
+            for req_file in ("test-requirements.txt", "requirements-test.txt", "requirements.txt"):
+                try:
+                    with (cwd / req_file).open() as fileh:
+                        deps.extend(fileh.read().splitlines())
+                except FileNotFoundError:
+                    pass
 
     return "\n".join(deps)
 

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -681,7 +681,7 @@ def conf_deps(env_conf: EnvConfigSet, test_type: str) -> str:  # noqa: ARG001
                 try:
                     with (cwd / req_file).open() as fileh:
                         deps.extend(fileh.read().splitlines())
-                except FileNotFoundError:
+                except FileNotFoundError:  # noqa: PERF203
                     pass
 
     return "\n".join(deps)

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -512,6 +512,30 @@ def test_conf_deps(tmp_path: Path) -> None:
         assert "requirement" in result
         assert "requirement-test" in result
         assert "github.com/ansible/ansible" not in result
+        assert "molecule" not in result
+
+
+def test_conf_deps_integration(tmp_path: Path) -> None:
+    """Test the conf_deps function includes molecule for integration tests.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+
+    with working_directory(tmp_path):
+        conf = Config.make(
+            Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+            pos_args=[],
+            source=source,
+            extra_envs=[],
+        ).get_env("integration-py3.14-2.19")
+
+        result = conf_deps(env_conf=conf, test_type="integration")
+        assert "ansible-dev-environment>=26.2.0" in result
+        assert "molecule>=26.4.0" in result
 
 
 def test_conf_deps_sanity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `molecule>=26.4.0` as an automatic dependency for integration test environments, ensuring molecule is available when running integration tests via tox-ansible.
- Unit and sanity test environments are unaffected.

## Reasoning
Collections that use molecule for integration testing currently need to manually specify molecule in their requirements files. Since molecule is a core tool for running Ansible integration tests, tox-ansible should install it automatically for integration environments, consistent with how `pytest` and `pytest-ansible` are already provided.

Fixes https://github.com/ansible/tox-ansible/issues/549

## Test plan
- [x] New unit test `test_conf_deps_integration` verifies molecule is included in integration deps
- [x] Existing `test_conf_deps` updated to verify molecule is NOT included in unit deps
- [x] All 33 unit tests pass
- [x] Linting passes