### PR TITLE
Fix: Update tox-ansible matrix to drop Python 3.12 for devel and also remove EOL for ansible-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -455,6 +455,7 @@ dependency_groups = ["lint"]
 skip_install = true
 
 [tool.tox.env.devel]
+base_python = ["python3.13"]
 dependency_groups = ["dev"]
 deps = [
   "ansible-compat @ git+https://github.com/ansible/ansible-compat.git",

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -46,10 +46,9 @@ ALLOWED_EXTERNALS = [
 ]
 ENV_LIST = """
 galaxy
-{integration, sanity, unit}-py3.10-{2.16, 2.17}
-{integration, sanity, unit}-py3.11-{2.17, 2.18, 2.19}
-{integration, sanity, unit}-py3.12-{2.17, 2.18, 2.19, 2.20, 2.21, milestone, devel}
-{integration, sanity, unit}-py3.13-{2.18, 2.19, 2.20, 2.21, milestone, devel}
+{integration, sanity, unit}-py3.11-{ 2.19 }
+{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21, milestone}
+{integration, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
 {integration, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
 """
 # ^ py314 is NOT supported before 2.20! If is in official metadata of the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from _pytest.python import Metafunc
 
-GH_MATRIX_LENGTH = 58
+GH_MATRIX_LENGTH = 34
 
 
 def run(  # noqa: PLR0913

--- a/tests/fixtures/integration/test_user_provided/tox-ansible.ini
+++ b/tests/fixtures/integration/test_user_provided/tox-ansible.ini
@@ -14,7 +14,7 @@ commands =
 allowlist_externals =
     root
 
-[testenv:integration-py3.12-devel]
+[testenv:integration-py3.13-devel]
 pass_env =
     specific
 

--- a/tests/fixtures/unit/test_type/tox-ansible.ini
+++ b/tests/fixtures/unit/test_type/tox-ansible.ini
@@ -14,10 +14,10 @@ commands =
 allowlist_externals =
     root
 
-[testenv:integration-py3.12-devel]
+[testenv:integration-py3.13-devel]
 pass_env =
     specific
 
 [ansible]
 skip =
-    devel
+    milestone

--- a/tests/integration/test_user_provided.py
+++ b/tests/integration/test_user_provided.py
@@ -49,7 +49,7 @@ def test_user_provided(
         assert cfg_parser.get(env_name, "deps") == "root"
         assert "root" in cfg_parser.get(env_name, "set_env")
         assert "milestone" not in env_name
-    assert "specific" in cfg_parser.get("testenv:integration-py3.12-devel", "pass_env")
+    assert "specific" in cfg_parser.get("testenv:integration-py3.13-devel", "pass_env")
 
 
 def test_user_provided_matrix_success(


### PR DESCRIPTION
Update tox-ansible matrix to drop EOL Python and ansible-core versions
- Remove Python 3.10 (EOL) and ansible-core 2.16/2.17 (EOL)
- Remove devel from Python 3.12 (no longer supported upstream)
- Narrow Python 3.11 to ansible-core 2.19 only
- Keep devel targets on Python 3.13 and 3.14 only