### PR TITLE
fix: drop milestone from Python 3.12 matrix

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -47,7 +47,7 @@ ALLOWED_EXTERNALS = [
 ENV_LIST = """
 galaxy
 {integration, sanity, unit}-py3.11-{ 2.19 }
-{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21, milestone}
+{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21}
 {integration, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
 {integration, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
 """


### PR DESCRIPTION
The ansible-core milestone branch now sets \`python_requires >= 3.13\`, mirroring the change previously made on the devel branch. This causes tox to fail when creating py3.12 environments for milestone:

ERROR: requires a different Python: 3.12.13 not in '>=3.13'
  - Remove milestone from the py3.12 row in ENV_LIST
  - Keep milestone on py3.13 and py3.14 where it is supported