### PR TITLE
Sonar/s3776-s1172-src

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -264,7 +264,7 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
             test_type=test_type,
         ),
         description=desc_for_env(env_conf.name),
-        deps=conf_deps(env_conf=env_conf, test_type=test_type),
+        deps=conf_deps(test_type=test_type),
         passenv=conf_passenv(),
         setenv=conf_setenv(env_conf=env_conf, test_type=test_type),
         skip_install=True,
@@ -395,6 +395,25 @@ def _gen_version(candidates: list[str]) -> str:
     return f"{candidates[0][0]}.{candidates[0][1:]}"
 
 
+def _extract_py_candidates(env_name: str) -> list[str]:
+    """Extract Python version candidates from an environment name.
+
+    Args:
+        env_name: The tox environment name (e.g. "unit-py3.11-2.19").
+
+    Returns:
+        A list of Python version strings found in the environment factors.
+    """
+    if env_name == "galaxy":
+        return ["3.14"]
+    candidates = []
+    for factor in env_name.split("-"):
+        match = PY_FACTORS_RE.match(factor)
+        if match:
+            candidates.append(match[2])
+    return candidates
+
+
 def generate_gh_matrix(env_list: EnvList, section: str) -> None:
     """Generate the github matrix.
 
@@ -406,14 +425,8 @@ def generate_gh_matrix(env_list: EnvList, section: str) -> None:
     for env_name in env_list.envs:
         if section != "all" and not env_name.startswith(section):  # pragma: no cover
             continue
-        candidates = []
         factors = env_name.split("-")
-        for factor in factors:
-            match = PY_FACTORS_RE.match(factor)
-            if match:
-                candidates.append(match[2])
-        if env_name == "galaxy":
-            candidates = ["3.14"]
+        candidates = _extract_py_candidates(env_name)
 
         _check_num_candidates(candidates=candidates, env_name=env_name)
         version = _gen_version(candidates=candidates)
@@ -525,7 +538,6 @@ def conf_commands(
         return conf_commands_for_galaxy(
             collection=collection,
             env_conf=env_conf,
-            pos_args=pos_args,
         )
     err = f"Unknown test type {test_type}"
     logger.critical(err)
@@ -588,14 +600,12 @@ def conf_commands_for_sanity(
 def conf_commands_for_galaxy(
     collection: Collection,  # noqa: ARG001
     env_conf: EnvConfigSet,
-    pos_args: tuple[str, ...] | None,  # noqa: ARG001
 ) -> list[str]:
     """Add commands for sanity tests.
 
     Args:
         collection: The collection info.
         env_conf: The tox environment configuration object.
-        pos_args: Positional arguments passed to tox command.
 
     Returns:
         The commands to run.
@@ -721,11 +731,10 @@ def conf_commands_pre(
     return commands
 
 
-def conf_deps(env_conf: EnvConfigSet, test_type: str) -> str:  # noqa: ARG001
+def conf_deps(test_type: str) -> str:
     """Add dependencies to the tox environment.
 
     Args:
-        env_conf: The tox environment configuration object.
         test_type: The test type, either "integration", "unit", or "sanity".
 
     Returns:

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -47,7 +47,7 @@ ALLOWED_EXTERNALS = [
 ENV_LIST = """
 galaxy
 {integration, sanity, unit}-py3.11-{ 2.19 }
-{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21, milestone}
+{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21}
 {integration, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
 {integration, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
 """

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -722,26 +722,13 @@ def test_conf_deps(tmp_path: Path) -> None:
     Args:
         tmp_path: Pytest fixture.
     """
-    ini_file = tmp_path / "tox.ini"
-    ini_file.touch()
-    source = discover_source(ini_file, None)
-
     (tmp_path / "test-requirements.txt").write_text("test-requirement")
     (tmp_path / "requirements.txt").write_text("requirement")
     (tmp_path / "requirements-test.txt").write_text("requirement-test")
 
-    # test will fail if current directory is not the one with the config as we
-    # would not be able to find the extra config. Tox config objects do not
-    # include any information regarding the config file location.
+    # conf_deps reads requirement files relative to Path.cwd().
     with working_directory(tmp_path):
-        conf = Config.make(
-            Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
-            pos_args=[],
-            source=source,
-            extra_envs=[],
-        ).get_env("unit-py3.14-2.19")
-
-        result = conf_deps(env_conf=conf, test_type="unit")
+        result = conf_deps(test_type="unit")
         assert "ansible-dev-environment>=26.2.0" in result
         assert "test-requirement" in result
         assert "requirement" in result
@@ -756,41 +743,15 @@ def test_conf_deps_integration(tmp_path: Path) -> None:
     Args:
         tmp_path: Pytest fixture.
     """
-    ini_file = tmp_path / "tox.ini"
-    ini_file.touch()
-    source = discover_source(ini_file, None)
-
     with working_directory(tmp_path):
-        conf = Config.make(
-            Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
-            pos_args=[],
-            source=source,
-            extra_envs=[],
-        ).get_env("integration-py3.14-2.19")
-
-        result = conf_deps(env_conf=conf, test_type="integration")
+        result = conf_deps(test_type="integration")
         assert "ansible-dev-environment>=26.2.0" in result
         assert "molecule>=26.4.0" in result
 
 
-def test_conf_deps_sanity(tmp_path: Path) -> None:
-    """Test the conf_deps function for sanity tests.
-
-    Args:
-        tmp_path: Pytest fixture.
-    """
-    ini_file = tmp_path / "tox.ini"
-    ini_file.touch()
-    source = discover_source(ini_file, None)
-
-    conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
-        pos_args=[],
-        source=source,
-        extra_envs=[],
-    ).get_env("sanity-py3.13-2.19")
-
-    result = conf_deps(env_conf=conf, test_type="sanity")
+def test_conf_deps_sanity() -> None:
+    """Test the conf_deps function for sanity tests."""
+    result = conf_deps(test_type="sanity")
     assert "ansible-dev-environment>=26.2.0" in result
     assert "pytest" not in result
 


### PR DESCRIPTION

Fix | SonarCloud Rule | What changed
-- | -- | --
Extracted _extract_py_candidates() helper | S3776 (cognitive complexity) | Inner loop from generate_gh_matrix moved to a new function, reducing complexity below the threshold
Removed pos_args param from conf_commands_for_galaxy | S1172 (unused param) | Removed unused parameter and its # noqa: ARG001, updated call site in conf_commands
Removed env_conf param from conf_deps | S1172 (unused param) | Removed unused parameter and its # noqa: ARG001, updated call site in tox_add_env_config

