### PR TITLE
feat: expand Python dependency file locations in conf_deps

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -77,6 +77,16 @@ TEST_REQUIREMENTS_YML: dict[str, list[str]] = {
     ],
 }
 
+PYTHON_DEPENDENCY_FILES: list[str] = [
+    "test-requirements.txt",
+    "requirements-test.txt",
+    "requirements.txt",
+    "tests/unit/requirements.txt",
+    "tests/integration/requirements.txt",
+    # https://docs.ansible.com/projects/builder/en/latest/collection_metadata/
+    "meta/ee-requirements.txt",
+]
+
 T = TypeVar("T", bound=ConfigSet)
 
 
@@ -750,7 +760,7 @@ def conf_deps(test_type: str) -> str:
             deps.extend(OUR_DEPS)
             if test_type == "integration":
                 deps.append("molecule>=26.4.0")
-            for req_file in ("test-requirements.txt", "requirements-test.txt", "requirements.txt"):
+            for req_file in PYTHON_DEPENDENCY_FILES:
                 try:
                     with (cwd / req_file).open() as fileh:
                         deps.extend(fileh.read().splitlines())

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -24,6 +24,7 @@ from tox.report import ToxHandler
 from tox.session.state import State
 
 from tox_ansible.plugin import (
+    PYTHON_DEPENDENCY_FILES,
     Collection,
     _load_pyproject_config,
     add_ansible_matrix,
@@ -735,6 +736,26 @@ def test_conf_deps(tmp_path: Path) -> None:
         assert "requirement-test" in result
         assert "github.com/ansible/ansible" not in result
         assert "molecule" not in result
+
+
+def test_conf_deps_all_dependency_files(tmp_path: Path) -> None:
+    """Test that conf_deps picks up all PYTHON_DEPENDENCY_FILES locations.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    expected: dict[str, str] = {}
+    for req_file in PYTHON_DEPENDENCY_FILES:
+        dep_name = f"dep-from-{req_file.replace('/', '-').replace('.txt', '')}"
+        req_path = tmp_path / req_file
+        req_path.parent.mkdir(parents=True, exist_ok=True)
+        req_path.write_text(dep_name)
+        expected[req_file] = dep_name
+
+    with working_directory(tmp_path):
+        result = conf_deps(test_type="unit")
+        for req_file, dep_name in expected.items():
+            assert dep_name in result, f"Dependency from {req_file} not found in result"
 
 
 def test_conf_deps_integration(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `PYTHON_DEPENDENCY_FILES` constant listing all requirement file paths that `conf_deps` searches for: `test-requirements.txt`, `requirements-test.txt`, `requirements.txt`, `tests/unit/requirements.txt`, `tests/integration/requirements.txt`, and `meta/ee-requirements.txt`
- Update `conf_deps` to iterate over the constant instead of an inline tuple
- Add test verifying all file locations are picked up

## Test plan
- [x] New `test_conf_deps_all_dependency_files` test creates every file from `PYTHON_DEPENDENCY_FILES` and verifies each is included in the result
- [x] All 93 existing tests pass
- [x] Pre-commit hooks pass (ruff, pylint, mypy, pydoclint, toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)