### PR TITLE
feat: add unit test coverage reporting

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -3,6 +3,7 @@ autouse
 calver
 caplog
 capsys
+coveragerc
 delenv
 endgroup
 envdir

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Coverage is disabled by default and can also be enabled for a single invocation:
 tox --ansible --coverage -e unit-py3.13-2.19
 ```
 
-tox-ansible installs `pytest-cov` and generates the collection-specific coverage configuration automatically. Use `--no-coverage` to override configuration that enables coverage.
+tox-ansible installs `pytest-cov` and generates the collection-specific coverage configuration automatically. Reports include eligible Python files below `plugins/` that the unit tests do not import, showing them with 0% coverage. Raw coverage data is stored separately inside each tox unit environment, so parallel environments produce independent reports rather than a combined matrix report. Use `--no-coverage` to override configuration that enables coverage.
 
 See the [configuration guide] for details on overriding environment settings.
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,33 @@ tox --ansible --gh-matrix --matrix-scope unit
 ```toml
 # pyproject.toml
 [tool.tox-ansible]
+coverage = true
 skip = [
     "2.16",
     "devel",
 ]
 ```
 
-This will skip tests in any environment that uses Ansible 2.16 or the devel branch. The list of strings is used for a simple string in string comparison of environment names.
+This will generate plugin coverage reports for unit test environments and skip tests in any environment that uses Ansible 2.16 or the devel branch. The list of strings is used for a simple string in string comparison of environment names.
 
 Alternatively, if using a `tox-ansible.ini` file, configure the `[ansible]` section:
 
 ```ini
 # tox-ansible.ini
 [ansible]
+coverage = true
 skip =
     2.16
     devel
 ```
+
+Coverage is disabled by default and can also be enabled for a single invocation:
+
+```bash
+tox --ansible --coverage -e unit-py3.13-2.19
+```
+
+tox-ansible installs `pytest-cov` and generates the collection-specific coverage configuration automatically. Use `--no-coverage` to override configuration that enables coverage.
 
 See the [configuration guide] for details on overriding environment settings.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,13 +9,14 @@ Add a `[tool.tox-ansible]` section to your collection's `pyproject.toml`:
 ```toml
 # pyproject.toml
 [tool.tox-ansible]
+coverage = true
 skip = [
     "2.16",
     "devel",
 ]
 ```
 
-This will skip tests in any environment whose name contains `2.16` or `devel`. The list of strings is used for a simple substring comparison against environment names.
+This enables coverage reporting for unit test environments and skips tests in any environment whose name contains `2.16` or `devel`. The list of strings is used for a simple substring comparison against environment names.
 
 When using `pyproject.toml`, tox also needs a `[tool.tox]` section (even if empty) so it can discover the file as its configuration source:
 
@@ -41,6 +42,7 @@ Alternatively, `tox-ansible` reads the `[ansible]` section from whatever tox con
 ```ini
 # tox-ansible.ini
 [ansible]
+coverage = true
 skip =
     2.16
     devel
@@ -53,6 +55,22 @@ tox --ansible --conf tox-ansible.ini
 Using a separate `tox-ansible.ini` file avoids conflicts with an existing `tox.ini` that may already define `[testenv]` sections for other purposes.
 
 If both `pyproject.toml` and `tox-ansible.ini` contain configuration, `pyproject.toml` takes precedence.
+
+## Unit test coverage
+
+Coverage reporting is disabled by default. Enable it persistently with `coverage = true` in either configuration format, or for a single invocation with `--coverage`:
+
+```bash
+tox --ansible --coverage -e unit-py3.13-2.19
+```
+
+When enabled, tox-ansible installs `pytest-cov`, generates coverage configuration for the collection under tox's work directory, and reports coverage for Python files below the collection's `plugins/` directory. No project-level `.coveragerc` is required.
+
+Coverage applies only to `unit-*` environments. Integration, sanity, and galaxy environments remain unchanged. Explicit CLI options take precedence over project configuration, so configured coverage can be disabled temporarily:
+
+```bash
+tox --ansible --no-coverage -e unit-py3.13-2.19
+```
 
 ## Overriding the configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,9 @@ Coverage reporting is disabled by default. Enable it persistently with `coverage
 tox --ansible --coverage -e unit-py3.13-2.19
 ```
 
-When enabled, tox-ansible installs `pytest-cov`, generates coverage configuration for the collection under tox's work directory, and reports coverage for Python files below the collection's `plugins/` directory. No project-level `.coveragerc` is required.
+When enabled, tox-ansible installs `pytest-cov`, generates coverage configuration for the collection under tox's work directory, and reports coverage for Python files below the collection's `plugins/` directory. Eligible files that the unit tests do not import appear with 0% coverage. No project-level `.coveragerc` is required.
+
+Raw coverage data is stored inside each tox unit environment. This keeps parallel environments isolated; reports from the Python and ansible-core matrix are independent and are not automatically combined.
 
 Coverage applies only to `unit-*` environments. Integration, sanity, and galaxy environments remain unchanged. Explicit CLI options take precedence over project configuration, so configured coverage can be disabled temporarily:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,7 @@ pip install tox-ansible
 - `pytest-ansible` version 3.1.0 or greater.
 - `pytest`
 - `pytest-xdist`
+- `pytest-cov` when unit test coverage is enabled
 - `pyyaml`
 
 Each generated test environment will also install:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -143,7 +143,9 @@ Use `--coverage` to generate a coverage report for Python files in the collectio
 tox -e unit-py3.13-2.19 --ansible --coverage
 ```
 
-tox-ansible installs `pytest-cov` and generates the required path mappings automatically, including the collection-specific installation path created by Ansible Dev Environment. The collection does not need a `.coveragerc` or a custom unit test command.
+tox-ansible installs `pytest-cov` and generates the required path mappings automatically, including the collection-specific installation path created by Ansible Dev Environment. Eligible Python files below `plugins/` that the unit tests do not import appear with 0% coverage. The collection does not need a `.coveragerc` or a custom unit test command.
+
+Each unit environment stores its raw coverage data in its own tox environment directory. Parallel environments therefore produce independent reports; tox-ansible does not automatically combine results across the Python and ansible-core matrix.
 
 Coverage can also be enabled persistently with `coverage = true` in `[tool.tox-ansible]` in `pyproject.toml` or `[ansible]` in `tox-ansible.ini`. See the [Configuration](configuration.md#unit-test-coverage) page for examples and precedence rules.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -135,6 +135,24 @@ Same can be done to pass arguments to the `pytest` commands for the `unit-*` and
 tox -e unit-py3.13-2.19 --ansible -- --junit-xml=tests/output/junit/unit.xml
 ```
 
+## Unit test coverage
+
+Use `--coverage` to generate a coverage report for Python files in the collection's `plugins/` directory while running unit tests:
+
+```bash
+tox -e unit-py3.13-2.19 --ansible --coverage
+```
+
+tox-ansible installs `pytest-cov` and generates the required path mappings automatically, including the collection-specific installation path created by Ansible Dev Environment. The collection does not need a `.coveragerc` or a custom unit test command.
+
+Coverage can also be enabled persistently with `coverage = true` in `[tool.tox-ansible]` in `pyproject.toml` or `[ansible]` in `tox-ansible.ini`. See the [Configuration](configuration.md#unit-test-coverage) page for examples and precedence rules.
+
+Additional pytest-cov options can be passed after `--`, for example:
+
+```bash
+tox -e unit-py3.13-2.19 --ansible --coverage -- --cov-report=xml
+```
+
 ## Usage in a CI/CD pipeline
 
 A GitHub Actions matrix is dynamically created by `tox-ansible` using the `--gh-matrix` and `--ansible` flags. The list of environments is converted to a list of entries in json format which is stored under the `envlist` key in the file specified by the `GITHUB_OUTPUT` environment variable.

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -890,6 +890,31 @@ def conf_commands_pre(
     return commands
 
 
+def _test_deps(test_type: str, *, coverage_enabled: bool) -> list[str]:
+    """Assemble dependencies for integration and unit test environments.
+
+    Args:
+        test_type: The test type, either "integration" or "unit".
+        coverage_enabled: Whether unit test coverage is enabled.
+
+    Returns:
+        The dependencies as a list of requirement strings.
+    """
+    deps = list(OUR_DEPS)
+    if test_type == "unit" and coverage_enabled:
+        deps.extend(COVERAGE_DEPS)
+    if test_type == "integration":
+        deps.append("molecule>=26.4.0")
+    cwd = Path.cwd()
+    for req_file in PYTHON_DEPENDENCY_FILES:
+        try:
+            with (cwd / req_file).open() as fileh:
+                deps.extend(fileh.read().splitlines())
+        except FileNotFoundError:  # noqa: PERF203
+            pass
+    return deps
+
+
 def conf_deps(test_type: str, *, coverage_enabled: bool = False) -> str:
     """Add dependencies to the tox environment.
 
@@ -900,25 +925,13 @@ def conf_deps(test_type: str, *, coverage_enabled: bool = False) -> str:
     Returns:
         The dependencies.
     """
-    deps = []
-    cwd = Path.cwd()
+    deps: list[str] = []
     if test_type == "galaxy":
         deps.append("galaxy-importer>=0.4.31")
     else:
         deps.append("ansible-dev-environment>=26.2.0")
         if test_type in ("integration", "unit"):
-            deps.extend(OUR_DEPS)
-            if test_type == "unit" and coverage_enabled:
-                deps.extend(COVERAGE_DEPS)
-            if test_type == "integration":
-                deps.append("molecule>=26.4.0")
-            for req_file in PYTHON_DEPENDENCY_FILES:
-                try:
-                    with (cwd / req_file).open() as fileh:
-                        deps.extend(fileh.read().splitlines())
-                except FileNotFoundError:  # noqa: PERF203
-                    pass
-
+            deps.extend(_test_deps(test_type, coverage_enabled=coverage_enabled))
     return "\n".join(deps)
 
 

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -63,6 +63,9 @@ OUR_DEPS = [
     "pytest-ansible>=v4.1.1",  # latest version still supporting py39 (Oct 2023)
     "ansible-compat>=25.11.0",  # Nov 2025
 ]
+COVERAGE_DEPS = [
+    "pytest-cov>=4.1.0",  # May 2023
+]
 
 # Paths checked for collection requirements files, keyed by test type.
 # From https://github.com/ansible/ansible-compat/blob/main/src/ansible_compat/constants.py#L6-L14
@@ -296,6 +299,12 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
         base_python = [factors[1]]
     test_type = factors[0]
     ansible_version = factors[-1] if len(factors) == expected_factors else ""
+    coverage_enabled = test_type == "unit" and _coverage_enabled(state)
+    coverage_config = (
+        _write_coverage_config(env_conf=env_conf, collection=collection)
+        if coverage_enabled
+        else None
+    )
 
     conf = AnsibleTestConf(
         allowlist_externals=ALLOWED_EXTERNALS,
@@ -311,9 +320,10 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
             env_conf=env_conf,
             pos_args=pos_args,
             test_type=test_type,
+            coverage_config=coverage_config,
         ),
         description=desc_for_env(env_conf.name),
-        deps=conf_deps(test_type=test_type),
+        deps=conf_deps(test_type=test_type, coverage_enabled=coverage_enabled),
         passenv=conf_passenv(),
         setenv=conf_setenv(env_conf=env_conf, test_type=test_type),
         skip_install=True,
@@ -416,7 +426,7 @@ def _coverage_enabled(state: State) -> bool:
     Returns:
         Whether unit test coverage is enabled.
     """
-    cli_coverage: bool | None = state.conf.options.coverage
+    cli_coverage: bool | None = getattr(state.conf.options, "coverage", None)
     if cli_coverage is not None:
         return cli_coverage
     return _load_ansible_config(state).coverage
@@ -590,11 +600,69 @@ def get_collection(galaxy_path: Path) -> Collection:
     return Collection(name=c_name, namespace=c_namespace, version=c_version)
 
 
+def _collection_install_path(env_conf: EnvConfigSet, collection: Collection) -> Path:
+    """Build the collection installation path inside a tox environment.
+
+    Args:
+        env_conf: The tox environment configuration object.
+        collection: The collection info.
+
+    Returns:
+        The installed collection path.
+    """
+    py_ver = env_conf.name.split("-")[1].replace("py", "")
+    return (
+        Path(env_conf["env_dir"])
+        / "lib"
+        / f"python{py_ver}"
+        / "site-packages"
+        / "ansible_collections"
+        / collection.namespace
+        / collection.name
+    )
+
+
+def _write_coverage_config(
+    env_conf: EnvConfigSet,
+    collection: Collection,
+) -> Path:
+    """Write an environment-specific coverage configuration.
+
+    Args:
+        env_conf: The tox environment configuration object.
+        collection: The collection info.
+
+    Returns:
+        The generated coverage configuration path.
+    """
+    coverage_dir = Path(env_conf["env_dir"]).parent / ".tox-ansible" / "coverage"
+    coverage_dir.mkdir(parents=True, exist_ok=True)
+    coverage_config = coverage_dir / f"{env_conf.name}.ini"
+    installed_plugins = _collection_install_path(env_conf, collection) / "plugins"
+    coverage_config.write_text(
+        "[run]\n"
+        "include =\n"
+        "    plugins/**/*.py\n"
+        f"    {installed_plugins}/**/*.py\n"
+        "\n"
+        "[paths]\n"
+        "source =\n"
+        "    plugins\n"
+        f"    {installed_plugins}\n"
+        "\n"
+        "[report]\n"
+        "show_missing = true\n",
+        encoding="utf-8",
+    )
+    return coverage_config
+
+
 def conf_commands(
     collection: Collection,
     env_conf: EnvConfigSet,
     pos_args: tuple[str, ...] | None,
     test_type: str,
+    coverage_config: Path | None = None,
 ) -> list[str]:
     """Build the commands for the tox environment.
 
@@ -603,6 +671,7 @@ def conf_commands(
         env_conf: The tox environment configuration object.
         pos_args: Positional arguments passed to tox command.
         test_type: The test type, either "integration", "unit", or "sanity".
+        coverage_config: The generated coverage configuration path.
 
     Returns:
         The commands to run.
@@ -611,6 +680,7 @@ def conf_commands(
         return conf_commands_for_integration_unit(
             pos_args=pos_args,
             test_type=test_type,
+            coverage_config=coverage_config,
         )
     if test_type == "sanity":
         return conf_commands_for_sanity(
@@ -631,21 +701,31 @@ def conf_commands(
 def conf_commands_for_integration_unit(
     pos_args: tuple[str, ...] | None,
     test_type: str,
+    coverage_config: Path | None = None,
 ) -> list[str]:
     """Build the commands for integration and unit tests.
 
     Args:
         pos_args: Positional arguments passed to tox command.
         test_type: The test type, either "integration" or "unit".
+        coverage_config: The generated coverage configuration path.
 
     Returns:
         The commands to run.
     """
     args = f" {' '.join(pos_args)} " if pos_args else " "
+    coverage_args = (
+        f" --cov --cov-config={coverage_config}"
+        if test_type == "unit" and coverage_config is not None
+        else ""
+    )
 
     # Use pytest ansible unit inject only to inject the collection path
     # into the collection finder
-    command = f"python3 -m pytest --ansible-unit-inject-only{args}{Path()}/tests/{test_type}"
+    command = (
+        f"python3 -m pytest{coverage_args} "
+        f"--ansible-unit-inject-only{args}{Path()}/tests/{test_type}"
+    )
     return [command]
 
 
@@ -669,11 +749,7 @@ def conf_commands_for_sanity(
     args = f" {' '.join(pos_args)}" if pos_args else ""
 
     py_ver = env_conf.name.split("-")[1].replace("py", "")
-
-    envdir = env_conf["env_dir"]
-    site_packages = f"{envdir}/lib/python{py_ver}/site-packages"
-    col_rel = f"ansible_collections/{collection.namespace}/{collection.name}"
-    collection_path = f"{site_packages}/{col_rel}"
+    collection_path = _collection_install_path(env_conf, collection)
 
     command = f"ansible-test sanity --local --requirements --python {py_ver}{args}"
     full_command = f"bash -c 'cd {collection_path} && {command}'"
@@ -739,7 +815,6 @@ def _add_sanity_git_init(
     commands: list[str],
     env_conf: EnvConfigSet,
     collection: Collection,
-    envdir: str,
     end_group: str,
 ) -> None:
     """Append git-init commands needed to work around ansible/ansible#68499.
@@ -748,13 +823,9 @@ def _add_sanity_git_init(
         commands: The command list to append to.
         env_conf: The tox environment configuration object.
         collection: The collection info.
-        envdir: The tox environment directory.
         end_group: The CI group-close command string.
     """
-    py_ver = env_conf.name.split("-")[1].replace("py", "")
-    site_packages = f"{envdir}/lib/python{py_ver}/site-packages"
-    col_rel = f"ansible_collections/{collection.namespace}/{collection.name}"
-    collection_path = f"{site_packages}/{col_rel}"
+    collection_path = _collection_install_path(env_conf, collection)
     if in_action():  # pragma: no cover
         commands.append("echo ::group::Initialize the collection to avoid ansible #68499")
     git_cfg = "git config --global init.defaultBranch main"
@@ -810,16 +881,17 @@ def conf_commands_pre(
         _add_collection_req_commands(commands, found_reqs, envdir, acv, end_group)
 
     if test_type == "sanity":
-        _add_sanity_git_init(commands, env_conf, collection, envdir, end_group)
+        _add_sanity_git_init(commands, env_conf, collection, end_group)
 
     return commands
 
 
-def conf_deps(test_type: str) -> str:
+def conf_deps(test_type: str, *, coverage_enabled: bool = False) -> str:
     """Add dependencies to the tox environment.
 
     Args:
         test_type: The test type, either "integration", "unit", or "sanity".
+        coverage_enabled: Whether unit test coverage is enabled.
 
     Returns:
         The dependencies.
@@ -832,6 +904,8 @@ def conf_deps(test_type: str) -> str:
         deps.append("ansible-dev-environment>=26.2.0")
         if test_type in ("integration", "unit"):
             deps.extend(OUR_DEPS)
+            if test_type == "unit" and coverage_enabled:
+                deps.extend(COVERAGE_DEPS)
             if test_type == "integration":
                 deps.append("molecule>=26.4.0")
             for req_file in PYTHON_DEPENDENCY_FILES:

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -96,11 +96,30 @@ class AnsibleConfigSet(ConfigSet):
     def register_config(self) -> None:
         """Register the ansible configuration."""
         self.add_config(
+            "coverage",
+            of_type=bool,
+            default=False,
+            desc="enable coverage reporting for unit tests",
+        )
+        self.add_config(
             "skip",
             of_type=list[str],
             default=[],
             desc="ansible configuration",
         )
+
+
+@dataclass
+class AnsibleConfiguration:
+    """User-provided tox-ansible configuration.
+
+    Attributes:
+        coverage: Enable coverage reporting for unit tests.
+        skip: Environment name fragments to skip.
+    """
+
+    coverage: bool = False
+    skip: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -182,6 +201,21 @@ def tox_add_option(parser: ToxParser) -> None:
         help="Enable ansible testing",
     )
 
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        default=None,
+        help="Enable coverage reporting for unit tests",
+    )
+
+    parser.add_argument(
+        "--no-coverage",
+        action="store_false",
+        default=None,
+        dest="coverage",
+        help="Disable coverage reporting for unit tests",
+    )
+
 
 @impl
 def tox_add_core_config(
@@ -196,6 +230,11 @@ def tox_add_core_config(
     """
     if state.conf.options.gh_matrix and not state.conf.options.ansible:  # pragma: no cover
         err = "The --gh-matrix option requires --ansible"
+        logger.critical(err)
+        sys.exit(1)
+
+    if state.conf.options.coverage and not state.conf.options.ansible:  # pragma: no cover
+        err = "The --coverage option requires --ansible"
         logger.critical(err)
         sys.exit(1)
 
@@ -336,6 +375,53 @@ def _load_pyproject_config(project_dir: Path) -> dict[str, Any] | None:
     return data.get("tool", {}).get("tox-ansible")
 
 
+def _load_ansible_config(state: State) -> AnsibleConfiguration:
+    """Load tox-ansible configuration using TOML-over-INI precedence.
+
+    Args:
+        state: The tox state object.
+
+    Returns:
+        The resolved tox-ansible configuration.
+    """
+    project_dir = state.conf.src_path.parent.resolve()
+    pyproject_config = _load_pyproject_config(project_dir)
+
+    if pyproject_config is not None:
+        return AnsibleConfiguration(
+            coverage=pyproject_config.get("coverage", False),
+            skip=pyproject_config.get("skip", []),
+        )
+
+    ansible_config = state.conf.get_section_config(
+        Section(None, "ansible"),
+        base=[],
+        of_type=AnsibleConfigSet,
+        for_env=None,
+    )
+    return AnsibleConfiguration(
+        coverage=ansible_config["coverage"],
+        skip=ansible_config["skip"],
+    )
+
+
+def _coverage_enabled(state: State) -> bool:
+    """Resolve coverage from the CLI and project configuration.
+
+    Explicit CLI options take precedence over project configuration.
+
+    Args:
+        state: The tox state object.
+
+    Returns:
+        Whether unit test coverage is enabled.
+    """
+    cli_coverage: bool | None = state.conf.options.coverage
+    if cli_coverage is not None:
+        return cli_coverage
+    return _load_ansible_config(state).coverage
+
+
 def add_ansible_matrix(state: State) -> EnvList:
     """Add the ansible matrix to the state.
 
@@ -345,19 +431,7 @@ def add_ansible_matrix(state: State) -> EnvList:
     Returns:
         The environment list.
     """
-    project_dir = state.conf.src_path.parent.resolve()
-    pyproject_config = _load_pyproject_config(project_dir)
-
-    if pyproject_config is not None:
-        skip_list: list[str] = pyproject_config.get("skip", [])
-    else:
-        ansible_config = state.conf.get_section_config(
-            Section(None, "ansible"),
-            base=[],
-            of_type=AnsibleConfigSet,
-            for_env=None,
-        )
-        skip_list = ansible_config["skip"]
+    skip_list = _load_ansible_config(state).skip
 
     env_list = StrConvert().to_env_list(ENV_LIST)
     env_list.envs = [env for env in env_list.envs if all(skip not in env for skip in skip_list)]

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -64,6 +64,7 @@ OUR_DEPS = [
     "ansible-compat>=25.11.0",  # Nov 2025
 ]
 COVERAGE_DEPS = [
+    "coverage>=7.0.0",  # Dec 2022
     "pytest-cov>=4.1.0",  # May 2023
 ]
 
@@ -639,11 +640,13 @@ def _write_coverage_config(
     coverage_dir.mkdir(parents=True, exist_ok=True)
     coverage_config = coverage_dir / f"{env_conf.name}.ini"
     installed_plugins = _collection_install_path(env_conf, collection) / "plugins"
+    coverage_data = Path(env_conf["env_dir"]).resolve() / ".coverage"
     coverage_config.write_text(
         "[run]\n"
-        "include =\n"
-        "    plugins/**/*.py\n"
-        f"    {installed_plugins}/**/*.py\n"
+        f"data_file = {coverage_data}\n"
+        "source =\n"
+        "    plugins\n"
+        f"    {installed_plugins}\n"
         "\n"
         "[paths]\n"
         "source =\n"
@@ -651,6 +654,7 @@ def _write_coverage_config(
         f"    {installed_plugins}\n"
         "\n"
         "[report]\n"
+        "include_namespace_packages = true\n"
         "show_missing = true\n",
         encoding="utf-8",
     )

--- a/tests/fixtures/integration/test_ade_workflow/plugins/module_utils/untested.py
+++ b/tests/fixtures/integration/test_ade_workflow/plugins/module_utils/untested.py
@@ -1,0 +1,6 @@
+"""An intentionally unimported plugin used to validate coverage discovery."""
+
+from __future__ import annotations
+
+
+UNTESTED_VALUE = True

--- a/tests/integration/test_ade_workflow.py
+++ b/tests/integration/test_ade_workflow.py
@@ -111,6 +111,53 @@ def test_ade_workflow_collection_requirements(
             )
 
 
+@pytest.mark.parametrize("config_format", ("ini", "toml"))
+def test_ade_workflow_coverage_config(
+    config_format: str,
+    module_fixture_dir: Path,
+    tmp_path: Path,
+    tox_bin: Path,
+) -> None:
+    """Validate INI and TOML configuration enable unit coverage only.
+
+    Args:
+        config_format: The tox-ansible configuration format to test.
+        module_fixture_dir: Pytest fixture for the module fixture directory.
+        tmp_path: Pytest fixture for a temporary directory.
+        tox_bin: Pytest fixture for the tox binary.
+    """
+    collection_dir = tmp_path / config_format
+    shutil.copytree(module_fixture_dir, collection_dir)
+    if config_format == "ini":
+        with (collection_dir / "tox-ansible.ini").open("a") as config_file:
+            config_file.write("\n[ansible]\ncoverage = true\n")
+    else:
+        (collection_dir / "pyproject.toml").write_text(
+            '[tool.tox]\nrequires = ["tox>=4.2"]\n\n[tool.tox-ansible]\ncoverage = true\n',
+        )
+
+    proc = run(
+        f"{tox_bin} config --ansible --root {collection_dir} --conf tox-ansible.ini "
+        "-e unit-py3.13-2.19,integration-py3.13-2.19 -k commands deps -qq",
+        cwd=collection_dir,
+        check=True,
+        timeout=10,
+    )
+    cfg_parser = ConfigParser()
+    cfg_parser.read_string(proc.stdout)
+    unit = cfg_parser["testenv:unit-py3.13-2.19"]
+    integration = cfg_parser["testenv:integration-py3.13-2.19"]
+    coverage_config = collection_dir / ".tox/.tox-ansible/coverage/unit-py3.13-2.19.ini"
+
+    assert "pytest-cov>=4.1.0" in unit["deps"]
+    assert "--cov --cov-config=" in unit["commands"]
+    assert coverage_config.is_file()
+    assert "ansible_collections/test_ns/test_col/plugins" in coverage_config.read_text()
+    assert "pytest-cov" not in integration["deps"]
+    assert "--cov" not in integration["commands"]
+    assert not (collection_dir / ".coveragerc").exists()
+
+
 @pytest.mark.slow
 def test_ade_workflow_e2e(
     module_fixture_dir: Path,
@@ -158,7 +205,7 @@ def test_ade_workflow_e2e(
     env_name = f"unit-py{py_ver}-{core_ver}"
 
     proc = subprocess.run(
-        [tox_bin, "--ansible", "--conf", "tox-ansible.ini", "-e", env_name],
+        [tox_bin, "--ansible", "--coverage", "--conf", "tox-ansible.ini", "-e", env_name],
         check=False,
         cwd=str(collection_dir),
         capture_output=True,
@@ -166,3 +213,7 @@ def test_ade_workflow_e2e(
     )
 
     assert proc.returncode == 0, f"tox run failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "plugins/modules/hello.py" in proc.stdout
+    assert "site-packages/ansible_collections/test_ns/test_col/plugins" not in proc.stdout
+    assert (collection_dir / ".coverage").is_file()
+    assert not (collection_dir / ".coveragerc").exists()

--- a/tests/integration/test_ade_workflow.py
+++ b/tests/integration/test_ade_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -149,10 +150,15 @@ def test_ade_workflow_coverage_config(
     integration = cfg_parser["testenv:integration-py3.13-2.19"]
     coverage_config = collection_dir / ".tox/.tox-ansible/coverage/unit-py3.13-2.19.ini"
 
+    assert "coverage>=7.0.0" in unit["deps"]
     assert "pytest-cov>=4.1.0" in unit["deps"]
     assert "--cov --cov-config=" in unit["commands"]
     assert coverage_config.is_file()
-    assert "ansible_collections/test_ns/test_col/plugins" in coverage_config.read_text()
+    coverage_content = coverage_config.read_text()
+    assert "source =\n    plugins\n" in coverage_content
+    assert "ansible_collections/test_ns/test_col/plugins" in coverage_content
+    assert "include_namespace_packages = true" in coverage_content
+    assert f"data_file = {collection_dir}/.tox/unit-py3.13-2.19/.coverage" in coverage_content
     assert "pytest-cov" not in integration["deps"]
     assert "--cov" not in integration["commands"]
     assert not (collection_dir / ".coveragerc").exists()
@@ -214,6 +220,11 @@ def test_ade_workflow_e2e(
 
     assert proc.returncode == 0, f"tox run failed:\n{proc.stdout}\n{proc.stderr}"
     assert "plugins/modules/hello.py" in proc.stdout
+    assert re.search(
+        r"plugins/module_utils/untested\.py\s+\d+\s+\d+\s+0%",
+        proc.stdout,
+    )
     assert "site-packages/ansible_collections/test_ns/test_col/plugins" not in proc.stdout
-    assert (collection_dir / ".coverage").is_file()
+    assert (collection_dir / ".tox" / env_name / ".coverage").is_file()
+    assert not (collection_dir / ".coverage").exists()
     assert not (collection_dir / ".coveragerc").exists()

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -26,6 +26,8 @@ from tox.session.state import State
 from tox_ansible.plugin import (
     PYTHON_DEPENDENCY_FILES,
     Collection,
+    _coverage_enabled,
+    _load_ansible_config,
     _load_pyproject_config,
     add_ansible_matrix,
     conf_commands,
@@ -1207,3 +1209,76 @@ def test_load_pyproject_config_empty_section(tmp_path: Path) -> None:
     result = _load_pyproject_config(tmp_path)
     assert result is not None
     assert result.get("skip", []) == []
+
+
+def _make_state(
+    config_file: Path,
+    *,
+    coverage: bool | None = None,
+) -> State:
+    """Create a tox state for configuration resolution tests."""
+    source = discover_source(config_file, None)
+    parsed = Parsed(
+        work_dir=config_file.parent / ".tox",
+        override=[],
+        config_file=config_file,
+        root_dir=config_file.parent,
+        ansible=True,
+        coverage=coverage,
+    )
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)
+    return State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+
+def test_load_ansible_config_pyproject(tmp_path: Path) -> None:
+    """Test loading coverage configuration from pyproject.toml."""
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text(
+        '[tool.tox]\nrequires = ["tox>=4.2"]\n'
+        '[tool.tox-ansible]\ncoverage = true\nskip = ["devel"]\n',
+    )
+
+    result = _load_ansible_config(_make_state(config_file))
+
+    assert result.coverage is True
+    assert result.skip == ["devel"]
+
+
+def test_load_ansible_config_ini(tmp_path: Path) -> None:
+    """Test loading coverage configuration from tox-ansible.ini."""
+    config_file = tmp_path / "tox-ansible.ini"
+    config_file.write_text("[ansible]\ncoverage = true\nskip =\n    milestone\n")
+
+    result = _load_ansible_config(_make_state(config_file))
+
+    assert result.coverage is True
+    assert result.skip == ["milestone"]
+
+
+@pytest.mark.parametrize(
+    ("cli_coverage", "expected"),
+    ((True, True), (False, False), (None, True)),
+)
+def test_coverage_enabled_cli_precedence(
+    tmp_path: Path,
+    *,
+    cli_coverage: bool | None,
+    expected: bool,
+) -> None:
+    """Test explicit CLI coverage options override project configuration."""
+    config_file = tmp_path / "tox-ansible.ini"
+    config_file.write_text("[ansible]\ncoverage = true\n")
+
+    result = _coverage_enabled(_make_state(config_file, coverage=cli_coverage))
+
+    assert result is expected

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -615,7 +615,11 @@ def test_conf_commands_unit(tmp_path: Path) -> None:
 
 
 def test_conf_commands_unit_coverage(tmp_path: Path) -> None:
-    """Test coverage arguments are added to unit test commands."""
+    """Test coverage arguments are added to unit test commands.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     ini_file = tmp_path / "tox.ini"
     ini_file.touch()
     source = discover_source(ini_file, None)
@@ -704,7 +708,11 @@ def test_conf_commands_integration(tmp_path: Path) -> None:
 
 
 def test_conf_commands_integration_ignores_coverage(tmp_path: Path) -> None:
-    """Test coverage configuration does not change integration commands."""
+    """Test coverage configuration does not change integration commands.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     ini_file = tmp_path / "tox.ini"
     ini_file.touch()
     source = discover_source(ini_file, None)
@@ -1275,7 +1283,15 @@ def _make_state(
     *,
     coverage: bool | None = None,
 ) -> State:
-    """Create a tox state for configuration resolution tests."""
+    """Create a tox state for configuration resolution tests.
+
+    Args:
+        config_file: The tox configuration file.
+        coverage: An explicit CLI coverage value.
+
+    Returns:
+        The configured tox state.
+    """
     source = discover_source(config_file, None)
     parsed = Parsed(
         work_dir=config_file.parent / ".tox",
@@ -1300,7 +1316,11 @@ def _make_state(
 
 
 def test_load_ansible_config_pyproject(tmp_path: Path) -> None:
-    """Test loading coverage configuration from pyproject.toml."""
+    """Test loading coverage configuration from pyproject.toml.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     config_file = tmp_path / "pyproject.toml"
     config_file.write_text(
         '[tool.tox]\nrequires = ["tox>=4.2"]\n'
@@ -1314,7 +1334,11 @@ def test_load_ansible_config_pyproject(tmp_path: Path) -> None:
 
 
 def test_load_ansible_config_ini(tmp_path: Path) -> None:
-    """Test loading coverage configuration from tox-ansible.ini."""
+    """Test loading coverage configuration from tox-ansible.ini.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     config_file = tmp_path / "tox-ansible.ini"
     config_file.write_text("[ansible]\ncoverage = true\nskip =\n    milestone\n")
 
@@ -1334,7 +1358,13 @@ def test_coverage_enabled_cli_precedence(
     cli_coverage: bool | None,
     expected: bool,
 ) -> None:
-    """Test explicit CLI coverage options override project configuration."""
+    """Test explicit CLI coverage options override project configuration.
+
+    Args:
+        tmp_path: Pytest fixture.
+        cli_coverage: An explicit CLI coverage value.
+        expected: The expected resolved coverage value.
+    """
     config_file = tmp_path / "tox-ansible.ini"
     config_file.write_text("[ansible]\ncoverage = true\n")
 
@@ -1344,7 +1374,11 @@ def test_coverage_enabled_cli_precedence(
 
 
 def test_collection_install_path(tmp_path: Path) -> None:
-    """Test the ADE collection path uses environment and collection metadata."""
+    """Test the ADE collection path uses environment and collection metadata.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     config_file = tmp_path / "tox.ini"
     config_file.touch()
     source = discover_source(config_file, None)
@@ -1372,7 +1406,11 @@ def test_collection_install_path(tmp_path: Path) -> None:
 
 
 def test_write_coverage_config(tmp_path: Path) -> None:
-    """Test generated coverage configuration maps installed and source plugins."""
+    """Test generated coverage configuration maps installed and source plugins.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
     config_file = tmp_path / "tox.ini"
     config_file.touch()
     source = discover_source(config_file, None)

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -841,9 +841,16 @@ def test_conf_deps_sanity() -> None:
 
 def test_conf_deps_coverage() -> None:
     """Test pytest-cov is installed only for opted-in unit tests."""
-    assert "pytest-cov>=4.1.0" in conf_deps(test_type="unit", coverage_enabled=True)
-    assert "pytest-cov" not in conf_deps(test_type="unit")
-    assert "pytest-cov" not in conf_deps(test_type="integration", coverage_enabled=True)
+    enabled_unit_deps = conf_deps(test_type="unit", coverage_enabled=True)
+    disabled_unit_deps = conf_deps(test_type="unit")
+    integration_deps = conf_deps(test_type="integration", coverage_enabled=True)
+
+    assert "coverage>=7.0.0" in enabled_unit_deps
+    assert "pytest-cov>=4.1.0" in enabled_unit_deps
+    assert "coverage>=7.0.0" not in disabled_unit_deps
+    assert "pytest-cov" not in disabled_unit_deps
+    assert "coverage>=7.0.0" not in integration_deps
+    assert "pytest-cov" not in integration_deps
 
 
 def test_conf_setenv_collections_path(tmp_path: Path) -> None:
@@ -1439,8 +1446,44 @@ def test_write_coverage_config(tmp_path: Path) -> None:
         / ".tox/unit-py3.13-2.21/lib/python3.13/site-packages"
         / "ansible_collections/example/widgets/plugins"
     )
-    assert "plugins/**/*.py" in content
-    assert f"{installed_plugins}/**/*.py" in content
-    assert f"    {installed_plugins}\n" in content
+    assert "include =" not in content
+    assert "source =\n    plugins\n" in content
+    assert content.count(f"    {installed_plugins}\n") == 2
+    assert f"data_file = {tmp_path}/.tox/unit-py3.13-2.21/.coverage" in content
+    assert "include_namespace_packages = true" in content
     assert "show_missing = true" in content
     assert not (tmp_path / ".coveragerc").exists()
+
+
+def test_write_coverage_config_isolates_data_by_environment(tmp_path: Path) -> None:
+    """Test each unit environment receives a separate coverage data file.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    config_file = tmp_path / "tox.ini"
+    config_file.touch()
+    source = discover_source(config_file, None)
+    config = Config.make(
+        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    )
+    collection = Collection(name="widgets", namespace="example", version="1.0.0")
+    data_files = []
+
+    for env_name in ("unit-py3.13-2.20", "unit-py3.13-2.21"):
+        env_dir = tmp_path / ".tox" / env_name
+        env_conf = config.get_env(env_name)
+        env_conf.add_config(
+            keys=["env_dir", "envdir"],
+            of_type=Path,
+            default=env_dir,
+            desc="",
+        )
+        coverage_config = _write_coverage_config(env_conf=env_conf, collection=collection)
+        data_files.append(f"data_file = {env_dir}/.coverage")
+        assert data_files[-1] in coverage_config.read_text()
+
+    assert data_files[0] != data_files[1]

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -26,9 +26,11 @@ from tox.session.state import State
 from tox_ansible.plugin import (
     PYTHON_DEPENDENCY_FILES,
     Collection,
+    _collection_install_path,
     _coverage_enabled,
     _load_ansible_config,
     _load_pyproject_config,
+    _write_coverage_config,
     add_ansible_matrix,
     conf_commands,
     conf_commands_pre,
@@ -612,6 +614,33 @@ def test_conf_commands_unit(tmp_path: Path) -> None:
     assert result[0] == "python3 -m pytest --ansible-unit-inject-only ./tests/unit"
 
 
+def test_conf_commands_unit_coverage(tmp_path: Path) -> None:
+    """Test coverage arguments are added to unit test commands."""
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("unit-py3.14-2.19")
+    coverage_config = tmp_path / "coverage.ini"
+
+    result = conf_commands(
+        env_conf=conf,
+        collection=Collection(name="test", namespace="test", version="1.0.0"),
+        test_type="unit",
+        pos_args=("--cov-report=xml", "-v"),
+        coverage_config=coverage_config,
+    )
+
+    assert result == [
+        f"python3 -m pytest --cov --cov-config={coverage_config} "
+        "--ansible-unit-inject-only --cov-report=xml -v ./tests/unit",
+    ]
+
+
 def test_conf_commands_sanity(tmp_path: Path) -> None:
     """Test the conf_commands function.
 
@@ -672,6 +701,29 @@ def test_conf_commands_integration(tmp_path: Path) -> None:
     )
     assert len(result) == 1
     assert result[0] == "python3 -m pytest --ansible-unit-inject-only ./tests/integration"
+
+
+def test_conf_commands_integration_ignores_coverage(tmp_path: Path) -> None:
+    """Test coverage configuration does not change integration commands."""
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("integration-py3.14-2.19")
+
+    result = conf_commands(
+        env_conf=conf,
+        collection=Collection(name="test", namespace="test", version="1.0.0"),
+        test_type="integration",
+        pos_args=None,
+        coverage_config=tmp_path / "coverage.ini",
+    )
+
+    assert result == ["python3 -m pytest --ansible-unit-inject-only ./tests/integration"]
 
 
 def test_conf_commands_invalid(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -777,6 +829,13 @@ def test_conf_deps_sanity() -> None:
     result = conf_deps(test_type="sanity")
     assert "ansible-dev-environment>=26.2.0" in result
     assert "pytest" not in result
+
+
+def test_conf_deps_coverage() -> None:
+    """Test pytest-cov is installed only for opted-in unit tests."""
+    assert "pytest-cov>=4.1.0" in conf_deps(test_type="unit", coverage_enabled=True)
+    assert "pytest-cov" not in conf_deps(test_type="unit")
+    assert "pytest-cov" not in conf_deps(test_type="integration", coverage_enabled=True)
 
 
 def test_conf_setenv_collections_path(tmp_path: Path) -> None:
@@ -1282,3 +1341,68 @@ def test_coverage_enabled_cli_precedence(
     result = _coverage_enabled(_make_state(config_file, coverage=cli_coverage))
 
     assert result is expected
+
+
+def test_collection_install_path(tmp_path: Path) -> None:
+    """Test the ADE collection path uses environment and collection metadata."""
+    config_file = tmp_path / "tox.ini"
+    config_file.touch()
+    source = discover_source(config_file, None)
+    env_conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=config_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("unit-py3.13-2.21")
+    env_conf.add_config(
+        keys=["env_dir", "envdir"],
+        of_type=Path,
+        default=tmp_path / "custom-env",
+        desc="",
+    )
+
+    result = _collection_install_path(
+        env_conf,
+        Collection(name="widgets", namespace="example", version="1.0.0"),
+    )
+
+    assert result == (
+        tmp_path / "custom-env/lib/python3.13/site-packages/ansible_collections/example/widgets"
+    )
+
+
+def test_write_coverage_config(tmp_path: Path) -> None:
+    """Test generated coverage configuration maps installed and source plugins."""
+    config_file = tmp_path / "tox.ini"
+    config_file.touch()
+    source = discover_source(config_file, None)
+    env_conf = Config.make(
+        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("unit-py3.13-2.21")
+    env_conf.add_config(
+        keys=["env_dir", "envdir"],
+        of_type=Path,
+        default=tmp_path / ".tox/unit-py3.13-2.21",
+        desc="",
+    )
+
+    result = _write_coverage_config(
+        env_conf=env_conf,
+        collection=Collection(name="widgets", namespace="example", version="1.0.0"),
+    )
+
+    assert result == tmp_path / ".tox/.tox-ansible/coverage/unit-py3.13-2.21.ini"
+    content = result.read_text()
+    installed_plugins = (
+        tmp_path
+        / ".tox/unit-py3.13-2.21/lib/python3.13/site-packages"
+        / "ansible_collections/example/widgets/plugins"
+    )
+    assert "plugins/**/*.py" in content
+    assert f"{installed_plugins}/**/*.py" in content
+    assert f"    {installed_plugins}\n" in content
+    assert "show_missing = true" in content
+    assert not (tmp_path / ".coveragerc").exists()

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -752,10 +752,11 @@ def test_conf_commands_invalid(tmp_path: Path, caplog: pytest.LogCaptureFixture)
         extra_envs=[],
     ).get_env("invalid-py3.14-2.19")
 
+    collection = Collection(name="test", namespace="test", version="1.0.0")
     with pytest.raises(SystemExit, match="1"):
         conf_commands(
             env_conf=conf,
-            collection=Collection(name="test", namespace="test", version="1.0.0"),
+            collection=collection,
             test_type="invalid",
             pos_args=None,
         )

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1446,9 +1446,10 @@ def test_write_coverage_config(tmp_path: Path) -> None:
         / ".tox/unit-py3.13-2.21/lib/python3.13/site-packages"
         / "ansible_collections/example/widgets/plugins"
     )
+    expected_installed_path_entries = 2
     assert "include =" not in content
     assert "source =\n    plugins\n" in content
-    assert content.count(f"    {installed_plugins}\n") == 2
+    assert content.count(f"    {installed_plugins}\n") == expected_installed_path_entries
     assert f"data_file = {tmp_path}/.tox/unit-py3.13-2.21/.coverage" in content
     assert "include_namespace_packages = true" in content
     assert "show_missing = true" in content


### PR DESCRIPTION
## Summary

This PR adds opt-in pytest-cov reporting for Ansible collection unit test environments. It removes the need for collections to maintain their own `.coveragerc` or override tox-ansible's generated unit test commands by dynamically mapping the collection's source plugins to its Ansible Dev Environment installation path.

Coverage can be enabled for individual invocations or persistently through either supported tox-ansible configuration format. Reports include eligible plugin files that were not imported by the unit tests, and parallel tox environments keep their coverage data isolated.

Fixes #368

## Details

### Coverage configuration

- Add `--coverage` and `--no-coverage` CLI options.
- Add `coverage = true` support under `[tool.tox-ansible]` in `pyproject.toml` and `[ansible]` in `tox-ansible.ini`.
- Preserve TOML-over-INI precedence and allow explicit CLI options to override project configuration.
- Apply coverage only to `unit-*` environments, leaving integration, sanity, and galaxy environments unchanged.

### Unit environment generation

- Install `coverage>=7.0.0` and `pytest-cov>=4.1.0` only when unit test coverage is enabled.
- Generate an environment-specific coverage configuration under the tox work directory.
- Configure coverage source discovery for both the source-tree and ADE-installed `plugins/` directories, including namespace-style plugin directories, so eligible unimported files appear at 0%.
- Map the dynamically derived `site-packages/ansible_collections/<namespace>/<name>/plugins` path back to source-relative report paths.
- Store raw coverage data inside each unit tox environment so concurrent environments cannot overwrite or combine one another's results.
- Keep reports independent across the Python and ansible-core matrix rather than automatically aggregating them.

### Tests and documentation

- Add unit coverage for configuration precedence, dynamic paths, dependencies, generated pytest commands, source discovery, and distinct per-environment data files.
- Add integration coverage for both TOML and INI configuration.
- Extend the isolated collection workflow with an intentionally unimported plugin and verify it appears at 0% without exposing `site-packages` paths.
- Verify the collection root remains free of generated `.coverage` and `.coveragerc` files.
- Document unimported plugin reporting, per-environment raw data, parallel isolation, and independent matrix reports.

## Test Plan

- [x] `.venv/bin/pytest tests/unit/test_plugin.py -q` — 50 passed
- [x] `.venv/bin/pytest tests/integration/test_ade_workflow.py -m "not slow" -q` — 4 passed, 1 deselected
- [x] `.venv/bin/pytest tests/integration/test_ade_workflow.py::test_ade_workflow_e2e -q` — 1 passed
- [x] `.venv/bin/tox -e lint`
- [x] `.venv/bin/pytest` — 106 passed

Generated by Codex (GPT-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional unit-test coverage reporting via `--coverage` (or `coverage = true` in project config), with `--no-coverage` to disable.
  - Coverage is applied to unit environments only; integration/sanity runs are unchanged.
  - Coverage reports can be customized by passing additional `pytest-cov` options.
  - Coverage data is isolated per test environment.
- **Documentation**
  - Expanded coverage setup details for `pyproject.toml`, `tox-ansible.ini`, and unit test workflows.
- **Tests**
  - Added/extended coverage-related end-to-end and unit tests for INI and TOML configurations.
- **Chores**
  - Updated the spelling dictionary for the term “coveragerc”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->