### PR TITLE
fix: suppress tox.ini warning for pyproject configuration

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -339,7 +339,7 @@ def add_ansible_matrix(state: State) -> EnvList:
     project_dir = state.conf.src_path.parent.resolve()
     pyproject_config = _load_pyproject_config(project_dir)
 
-    if state.conf.src_path.name == "tox.ini" and pyproject_config is None:  # pragma: no cover
+    if state.conf.src_path.name == "tox.ini" and pyproject_config is None:
         msg = (
             "Using a default tox.ini file with tox-ansible plugin is not recommended."
             " Consider adding a [tool.tox-ansible] section to pyproject.toml or using"

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -202,15 +202,6 @@ def tox_add_core_config(
     if not state.conf.options.ansible:  # pragma: no cover
         return
 
-    if state.conf.src_path.name == "tox.ini":  # pragma: no cover
-        msg = (
-            "Using a default tox.ini file with tox-ansible plugin is not recommended."
-            " Consider adding a [tool.tox-ansible] section to pyproject.toml or using"
-            " a tox-ansible.ini file (`tox --ansible -c tox-ansible.ini`) to avoid"
-            " unintentionally overriding the tox-ansible environment configurations."
-        )
-        logger.warning(msg)
-
     env_list = add_ansible_matrix(state)
 
     if not state.conf.options.gh_matrix:  # pragma: no cover
@@ -347,6 +338,15 @@ def add_ansible_matrix(state: State) -> EnvList:
     """
     project_dir = state.conf.src_path.parent.resolve()
     pyproject_config = _load_pyproject_config(project_dir)
+
+    if state.conf.src_path.name == "tox.ini" and pyproject_config is None:  # pragma: no cover
+        msg = (
+            "Using a default tox.ini file with tox-ansible plugin is not recommended."
+            " Consider adding a [tool.tox-ansible] section to pyproject.toml or using"
+            " a tox-ansible.ini file (`tox --ansible -c tox-ansible.ini`) to avoid"
+            " unintentionally overriding the tox-ansible environment configurations."
+        )
+        logger.warning(msg)
 
     if pyproject_config is not None:
         skip_list: list[str] = pyproject_config.get("skip", [])

--- a/tests/fixtures/integration/test_pyproject_config/pyproject.toml
+++ b/tests/fixtures/integration/test_pyproject_config/pyproject.toml
@@ -1,5 +1,2 @@
-[tool.tox]
-requires = ["tox>=4.2"]
-
 [tool.tox-ansible]
 skip = ["devel", "milestone"]

--- a/tests/integration/test_pyproject_config.py
+++ b/tests/integration/test_pyproject_config.py
@@ -46,7 +46,7 @@ def test_pyproject_skip(
     except subprocess.CalledProcessError as exc:
         print(exc.stdout)
         print(exc.stderr)
-        pytest.fail(exc.stderr)
+        pytest.fail(f"stdout:\n{exc.stdout}\n\nstderr:\n{exc.stderr}")
 
     warning = "Using a default tox.ini file with tox-ansible plugin is not recommended"
     assert warning not in proc.stdout

--- a/tests/integration/test_pyproject_config.py
+++ b/tests/integration/test_pyproject_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 from typing import TYPE_CHECKING
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
 def test_pyproject_skip(
     module_fixture_dir: Path,
+    tmp_path: Path,
     tox_bin: Path,
 ) -> None:
     """Validate that [tool.tox-ansible] skip filters environments.
@@ -25,22 +27,30 @@ def test_pyproject_skip(
 
     Args:
         module_fixture_dir: pytest fixture for module fixture directory
+        tmp_path: Pytest temporary directory fixture
         tox_bin: pytest fixture for tox binary
     """
+    project_dir = tmp_path / "project"
+    shutil.copytree(module_fixture_dir, project_dir)
+
     try:
         proc = subprocess.run(
-            f"{tox_bin} list --ansible --root {module_fixture_dir}",
+            [tox_bin, "--ansible", "-l"],
             capture_output=True,
-            cwd=str(module_fixture_dir),
+            cwd=str(project_dir),
             text=True,
             check=True,
-            shell=True,
+            shell=False,
             env=os.environ,
         )
     except subprocess.CalledProcessError as exc:
         print(exc.stdout)
         print(exc.stderr)
         pytest.fail(exc.stderr)
+
+    warning = "Using a default tox.ini file with tox-ansible plugin is not recommended"
+    assert warning not in proc.stdout
+    assert warning not in proc.stderr
 
     env_names = proc.stdout.strip().splitlines()
     for name in env_names:

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1095,14 +1095,16 @@ def test_add_ansible_matrix_pyproject(
 def test_add_ansible_matrix_ini_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test add_ansible_matrix falls back to [ansible] section when no pyproject.toml.
+    """Test add_ansible_matrix falls back to [ansible] and warns for tox.ini.
 
     Args:
         tmp_path: Pytest fixture for temporary directory.
         monkeypatch: Pytest fixture for patching.
+        caplog: Pytest fixture for log capture.
     """
-    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file = tmp_path / "tox.ini"
     ini_file.write_text("[ansible]\nskip =\n    devel\n")
     (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
     monkeypatch.chdir(tmp_path)
@@ -1134,6 +1136,8 @@ def test_add_ansible_matrix_ini_fallback(
     )
 
     env_list = add_ansible_matrix(state)
+    expected = "Using a default tox.ini file with tox-ansible plugin is not recommended"
+    assert expected in caplog.text
     for env_name in env_list.envs:
         assert "devel" not in env_name
     assert any("unit" in name for name in env_list.envs)


### PR DESCRIPTION
## Summary

This PR prevents tox-ansible from recommending a standalone configuration file when the project already contains a `[tool.tox-ansible]` section. The warning is now emitted only when tox uses its assumed default `tox.ini` and no tox-ansible configuration exists in `pyproject.toml`.

## Details

### Configuration detection

- Move the default `tox.ini` warning check alongside the existing `pyproject.toml` configuration load.
- Suppress the warning whenever `[tool.tox-ansible]` is present, including when tox does not recognize the file as its primary configuration source.
- Preserve the existing warning when neither pyproject configuration nor a dedicated tox-ansible configuration is available.

### Integration coverage

- Remove `[tool.tox]` from the pyproject fixture so tox follows the assumed default `tox.ini` path that previously emitted the incorrect warning, while retaining `[tool.tox-ansible]` and its skip filters.
- Copy the fixture to an isolated temporary project because tox otherwise walks up from the fixture directory and discovers the repository-level `[tool.tox]` configuration, masking the regression.
- Invoke the reported `tox --ansible -l` command and verify that it applies skip filters without emitting the tox-ansible warning.

## Test Plan

- [x] `uv run pytest -q` — 93 tests passed.
- [x] `uv run ruff check src/tox_ansible/plugin.py tests/integration/test_pyproject_config.py`
- [x] `uv run ruff format --check src/tox_ansible/plugin.py tests/integration/test_pyproject_config.py`

Generated by Codex (GPT-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined configuration warnings so the default `tox.ini` notice appears only when relevant project configuration is missing.
  - Prevented unnecessary warnings when the project uses supported configuration in `pyproject.toml`.
  - Improved environment-listing behavior in projects configured through `pyproject.toml`.

- **Tests**
  - Expanded integration coverage to verify warning output and configuration behavior in isolated project copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->