### PR TITLE
fix: apply matrix scope to tox environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ To review the specific commands and configuration for each of the integration, s
 tox config --ansible
 ```
 
-Generate specific GitHub action matrix as per scope mentioned with `--matrix-scope`:
+Limit test execution to a specific scope with `--matrix-scope`:
+
+```bash
+tox --ansible --matrix-scope unit
+```
+
+The same option limits GitHub Actions matrix output when used with `--gh-matrix`:
 
 ```bash
 tox --ansible --gh-matrix --matrix-scope unit

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -75,7 +75,13 @@ To review the specific commands and configuration for each of the integration, s
 tox config --ansible
 ```
 
-Generate specific GitHub action matrix as per scope mentioned with `--matrix-scope`:
+Limit test execution to a specific scope with `--matrix-scope`:
+
+```bash
+tox --ansible --matrix-scope unit
+```
+
+The same option limits GitHub Actions matrix output when used with `--gh-matrix`:
 
 ```bash
 tox --ansible --gh-matrix --matrix-scope unit

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -165,7 +165,7 @@ def tox_add_option(parser: ToxParser) -> None:
         "--matrix-scope",
         default="all",
         choices=["all", "galaxy", "sanity", "integration", "unit"],
-        help="Emit a github matrix specific to scope mentioned",
+        help="Limit Ansible environments and GitHub matrix output to the selected scope",
     )
 
     parser.add_argument(
@@ -211,7 +211,7 @@ def tox_add_core_config(
         )
         logger.warning(msg)
 
-    env_list = add_ansible_matrix(state)
+    env_list = add_ansible_matrix(state, scope=state.conf.options.matrix_scope)
 
     if not state.conf.options.gh_matrix:  # pragma: no cover
         return
@@ -336,11 +336,25 @@ def _load_pyproject_config(project_dir: Path) -> dict[str, Any] | None:
     return data.get("tool", {}).get("tox-ansible")
 
 
-def add_ansible_matrix(state: State) -> EnvList:
+def _env_in_scope(env_name: str, scope: str) -> bool:
+    """Return whether an environment belongs to the requested scope.
+
+    Args:
+        env_name: The tox environment name.
+        scope: The requested matrix scope.
+
+    Returns:
+        Whether the environment belongs to the scope.
+    """
+    return scope in ("all", env_name) or env_name.startswith(f"{scope}-")
+
+
+def add_ansible_matrix(state: State, scope: str = "all") -> EnvList:
     """Add the ansible matrix to the state.
 
     Args:
         state: The state object.
+        scope: The matrix scope to add.
 
     Returns:
         The environment list.
@@ -360,7 +374,11 @@ def add_ansible_matrix(state: State) -> EnvList:
         skip_list = ansible_config["skip"]
 
     env_list = StrConvert().to_env_list(ENV_LIST)
-    env_list.envs = [env for env in env_list.envs if all(skip not in env for skip in skip_list)]
+    env_list.envs = [
+        env
+        for env in env_list.envs
+        if _env_in_scope(env, scope) and all(skip not in env for skip in skip_list)
+    ]
     env_list.envs = sorted(env_list.envs, key=custom_sort)
     state.conf.core.loaders.insert(
         0,
@@ -433,7 +451,7 @@ def generate_gh_matrix(env_list: EnvList, section: str) -> None:
     """
     results = []
     for env_name in env_list.envs:
-        if section != "all" and not env_name.startswith(section):  # pragma: no cover
+        if not _env_in_scope(env_name, section):  # pragma: no cover
             continue
         factors = env_name.split("-")
         candidates = _extract_py_candidates(env_name)

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -201,6 +201,30 @@ def test_setting_matrix_scope(
     assert all(entry["name"].startswith("integration") for entry in structured)
 
 
+def test_matrix_scope_filters_environments(module_fixture_dir: Path, tox_bin: Path) -> None:
+    """Test matrix scope filters normal tox environment selection.
+
+    Args:
+        module_fixture_dir: Pytest fixture containing the test configuration.
+        tox_bin: Pytest fixture providing the tox executable.
+    """
+    cmd = (
+        tox_bin,
+        "-l",
+        "--ansible",
+        "--matrix-scope",
+        "sanity",
+        "--conf",
+        "tox-ansible.ini",
+    )
+    proc = run(cmd, cwd=module_fixture_dir, check=True, shell=False)
+
+    assert "sanity-" in proc.stdout
+    assert "galaxy " not in proc.stdout
+    assert "integration-" not in proc.stdout
+    assert "unit-" not in proc.stdout
+
+
 def test_action_not_output(
     module_fixture_dir: Path,
     tox_bin: Path,

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -57,9 +57,9 @@ def test_env_in_scope(scope: str) -> None:
 
 
 def test_galaxy_env_in_scope() -> None:
-    """Test matching the unfactored galaxy environment."""
+    """Test matching the single-name galaxy environment."""
     assert _env_in_scope("galaxy", "galaxy")
-    assert not _env_in_scope("galaxyimport", "galaxy")
+    assert not _env_in_scope("galaxy_import", "galaxy")
 
 
 def test_commands_pre_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -26,6 +26,7 @@ from tox.session.state import State
 from tox_ansible.plugin import (
     PYTHON_DEPENDENCY_FILES,
     Collection,
+    _env_in_scope,
     _load_pyproject_config,
     add_ansible_matrix,
     conf_commands,
@@ -40,6 +41,25 @@ from tox_ansible.plugin import (
 
 if typing.TYPE_CHECKING:
     from collections.abc import Generator
+
+
+@pytest.mark.parametrize(
+    "scope",
+    ("all", "galaxy", "integration", "sanity", "unit"),
+)
+def test_env_in_scope(scope: str) -> None:
+    """Test matching an environment against every supported matrix scope.
+
+    Args:
+        scope: The matrix scope to test.
+    """
+    assert _env_in_scope("unit-py3.13-2.21", scope) is (scope in ("all", "unit"))
+
+
+def test_galaxy_env_in_scope() -> None:
+    """Test matching the unfactored galaxy environment."""
+    assert _env_in_scope("galaxy", "galaxy")
+    assert not _env_in_scope("galaxyimport", "galaxy")
 
 
 def test_commands_pre_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1085,8 +1105,9 @@ def test_add_ansible_matrix_pyproject(
         args=[],
     )
 
-    env_list = add_ansible_matrix(state)
+    env_list = add_ansible_matrix(state, scope="unit")
     for env_name in env_list.envs:
+        assert env_name.startswith("unit-")
         assert "devel" not in env_name
         assert "milestone" not in env_name
     assert any("unit" in name for name in env_list.envs)


### PR DESCRIPTION
## Summary

This PR makes `--matrix-scope` filter the tox environments selected for normal test execution, instead of limiting the option to GitHub matrix output. Commands such as `tox --ansible --matrix-scope unit` now run only the environments belonging to the requested scope.

Fixes #397

## Details

### Environment selection

- Add a shared scope-matching helper for generated Ansible environments.
- Apply the requested scope before registering the environment list with tox, while preserving configured `skip` filtering.
- Reuse the same matching behavior when generating GitHub Actions matrix output.

### Tests and documentation

- Add unit coverage for all supported scopes and scope/skip composition.
- Add an integration regression test confirming normal tox environment selection excludes unrelated scopes.
- Update the CLI help, README, and user guide to describe both execution and GitHub matrix filtering.

## Test Plan

- [x] `.venv/bin/ruff check src/tox_ansible/plugin.py tests/unit/test_plugin.py tests/integration/test_basic.py`
- [x] `.venv/bin/pytest -q` (`100 passed`)
- [x] `tox --ansible --matrix-scope unit --conf tox-ansible.ini --notest` selects only `unit-*` environments

Generated by Codex (GPT-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `--matrix-scope` now limits both tox-ansible test environments and generated GitHub Actions matrix entries.
  * Added clearer command examples for selecting scopes such as `unit` and `sanity`.

* **Documentation**
  * Updated the README and user guide to explain matrix-scope behavior and its use with `--gh-matrix`.

* **Bug Fixes**
  * Improved scope matching so only environments belonging to the selected scope are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->