### PR TITLE
feat: add molecule test type with full matrix and autodetection

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -16,6 +16,7 @@ fixturenames
 lifecycle
 metafunc
 passenv
+prerun
 redef
 reqs
 sdlc

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,9 @@ When `tox-ansible` sets up a test environment (e.g. `unit-py3.13-2.19`), it runs
 - **Test matrix**: Generates the Python version x Ansible version matrix (`py3.13-2.19`, `py3.12-devel`, etc.)
 - **GitHub Actions integration**: Produces JSON matrix output for CI workflows via `--gh-matrix`
 - **Environment configuration**: Sets up each tox env with the right dependencies, environment variables, and commands
-- **Test commands**: Configures `pytest` for unit/integration tests, `ansible-test sanity` for sanity tests, and `galaxy-importer` for galaxy tests
+- **Test commands**: Configures `pytest` for unit/integration tests, `molecule`
+  for molecule scenarios, `ansible-test sanity` for sanity tests, and
+  `galaxy-importer` for galaxy tests
 - **Skip/filter**: Allows users to skip specific Ansible versions via `skip` in `[tool.tox-ansible]` (pyproject.toml) or `[ansible]` (tox-ansible.ini)
 - **Downstream extras**: Optional `downstream = true` unions AAP/cert cores onto the upstream matrix (ADR-001); still not an AAP-only list
 - **Pre-test setup**: Delegates to ade with a single `ade install` call

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,29 @@ ansible-core extras onto the upstream matrix (`downstream = true`; see ADR-001),
 and skips tests in any environment whose name contains `devel`. The `skip` list
 is a simple substring comparison against environment names.
 
+### Molecule configuration
+
+Molecule testing is controlled by the `molecule` option:
+
+```toml
+# pyproject.toml
+[tool.tox-ansible]
+molecule = "auto"  # "auto" (default), "true", or "false"
+```
+
+- **`auto`** (default): molecule environments are included only if `extensions/molecule/` contains at least one scenario (a subdirectory with `molecule.yml`).
+- **`true`**: always include molecule environments, even if no scenarios are discovered.
+- **`false`**: never include molecule environments.
+
+Custom molecule commands can be specified with `molecule_commands`. When empty (the default), `tox-ansible` runs `python3 -m pytest --molecule ./tests/integration`:
+
+```toml
+[tool.tox-ansible]
+molecule_commands = [
+    "molecule test -s default",
+]
+```
+
 When using `pyproject.toml`, tox also needs a `[tool.tox]` section (even if empty) so it can discover the file as its configuration source:
 
 ```toml
@@ -30,6 +53,7 @@ requires = ["tox>=4.2"]
 
 [tool.tox-ansible]
 skip = ["devel"]
+molecule = "auto"
 ```
 
 With this in place, no `--conf` flag is needed:
@@ -49,6 +73,8 @@ coverage = true
 downstream = true
 skip =
     devel
+molecule = auto
+molecule_commands =
 ```
 
 ```bash
@@ -85,7 +111,7 @@ When enabled, tox-ansible installs `pytest-cov`, generates coverage configuratio
 
 Raw coverage data is stored inside each tox unit environment. This keeps parallel environments isolated; reports from the Python and ansible-core matrix are independent and are not automatically combined.
 
-Coverage applies only to `unit-*` environments. Integration, sanity, and galaxy environments remain unchanged. Explicit CLI options take precedence over project configuration, so configured coverage can be disabled temporarily:
+Coverage applies only to `unit-*` environments. Integration, sanity, molecule, and galaxy environments remain unchanged. Explicit CLI options take precedence over project configuration, so configured coverage can be disabled temporarily:
 
 ```bash
 tox --ansible --no-coverage -e unit-py3.13-2.19

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,14 +35,36 @@ molecule = "auto"  # "auto" (default), "true", or "false"
 - **`true`**: always include molecule environments, even if no scenarios are discovered.
 - **`false`**: never include molecule environments.
 
-Custom molecule commands can be specified with `molecule_commands`. When empty (the default), `tox-ansible` runs `python3 -m pytest --molecule ./tests/integration`:
+When included, molecule uses the **same Python × ansible-core matrix** as
+integration, unit, and sanity.
+
+The default command is `python3 -m molecule test --all`. Add CLI flags with
+`molecule_append`, or fully replace the command list with
+`molecule_commands` (which ignores the default and `molecule_append`):
 
 ```toml
 [tool.tox-ansible]
-molecule_commands = [
-    "molecule test -s default",
-]
+# Append to the default: python3 -m molecule test --all --workers 4
+molecule_append = ["--workers", "4"]
+
+# Or fully replace:
+# molecule_commands = ["molecule test -s default"]
 ```
+
+`shared_state`, `prerun`, inventory, and other scenario behavior belong in
+`extensions/molecule/config.yml` (Molecule's config), not in tox-ansible.
+
+### Integration autodetection
+
+`integration-*` environments are included only when the collection has
+integration content:
+
+- a non-empty `tests/integration/targets/` directory (ansible-test style), or
+- pytest modules under `tests/integration/` (`test_*.py` / `*_test.py`)
+
+Collections that migrate fully to Molecule scenarios (and remove ansible-test
+targets) automatically drop the integration matrix without extra `skip`
+entries.
 
 When using `pyproject.toml`, tox also needs a `[tool.tox]` section (even if empty) so it can discover the file as its configuration source:
 
@@ -54,6 +76,7 @@ requires = ["tox>=4.2"]
 [tool.tox-ansible]
 skip = ["devel"]
 molecule = "auto"
+molecule_append = ["--workers", "4"]
 ```
 
 With this in place, no `--conf` flag is needed:
@@ -74,6 +97,9 @@ downstream = true
 skip =
     devel
 molecule = auto
+molecule_append =
+    --workers
+    4
 molecule_commands =
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,14 @@ molecule_append = ["--workers", "4"]
 
 `shared_state`, `prerun`, inventory, and other scenario behavior belong in
 `extensions/molecule/config.yml` (Molecule's config), not in tox-ansible.
+ansible-creator scaffolds that file; leave `prerun` under collection control.
+
+Molecule `commands_pre` installs collection requirements (via ADE) from, when
+present:
+
+- `tests/requirements.yml`
+- `tests/integration/requirements.yml` (shared with integration during migration)
+- `tests/molecule/requirements.yml` (optional molecule-only deps)
 
 ### Integration autodetection
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -235,13 +235,29 @@ skip =
 
 ## Testing molecule scenarios
 
-Molecule is a first-class test type in `tox-ansible`. When molecule scenarios are detected in your collection, a `molecule-*` environment is automatically added to the test matrix.
+Molecule is a first-class test type in `tox-ansible`. When molecule scenarios
+are detected in your collection, `molecule-*` environments are added across the
+same Python × ansible-core matrix as the other test types.
 
 ### How it works
 
-`tox-ansible` looks for molecule scenarios under `extensions/molecule/` in your collection root. Each subdirectory containing a `molecule.yml` file is treated as a scenario. When at least one scenario is found, a `molecule-py3.14-2.20` environment is added to the matrix (using the latest stable Python and ansible-core versions).
+`tox-ansible` looks for molecule scenarios under `extensions/molecule/` in your
+collection root. Each subdirectory containing a `molecule.yml` file is treated
+as a scenario. When at least one scenario is found (or `molecule = "true"`),
+molecule environments are included for every supported Python/ansible-core
+pair.
 
-The `molecule` package is automatically installed as a dependency. Additional molecule plugins (e.g., `molecule-plugins[docker]`) can be added via your collection's `requirements.txt` or `test-requirements.txt`.
+The default command is `python3 -m molecule test --all`. Use
+`molecule_append` for extra CLI flags (for example `--workers 4`), or
+`molecule_commands` to fully replace the command list.
+
+If the collection has no ansible-test `tests/integration/targets/` and no
+pytest integration modules, `integration-*` environments are omitted
+automatically — useful after migrating targets into Molecule scenarios.
+
+The `molecule` package is automatically installed as a dependency. Additional
+molecule plugins (e.g., `molecule-plugins[docker]`) can be added via your
+collection's `requirements.txt` or `test-requirements.txt`.
 
 ### Collection directory structure
 
@@ -291,13 +307,13 @@ By default, molecule environments are auto-discovered (`molecule = "auto"`). You
 molecule = "auto"  # "auto", "true", or "false"
 ```
 
-To provide custom commands instead of the default `pytest --molecule` invocation:
+To provide custom commands instead of the default `molecule test --all`
+invocation, either append flags or fully replace:
 
 ```toml
 [tool.tox-ansible]
-molecule_commands = [
-    "molecule test -s default",
-]
+molecule_append = ["--workers", "4"]
+# molecule_commands = ["molecule test -s default"]
 ```
 
 See the [Configuration](configuration.md) page for full details.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -251,6 +251,10 @@ The default command is `python3 -m molecule test --all`. Use
 `molecule_append` for extra CLI flags (for example `--workers 4`), or
 `molecule_commands` to fully replace the command list.
 
+Before running Molecule, tox-ansible installs collection requirements with ADE
+from `tests/requirements.yml`, `tests/integration/requirements.yml`, and
+(optionally) `tests/molecule/requirements.yml` when those files exist.
+
 If the collection has no ansible-test `tests/integration/targets/` and no
 pytest integration modules, `integration-*` environments are omitted
 automatically — useful after migrating targets into Molecule scenarios.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -235,71 +235,69 @@ skip =
 
 ## Testing molecule scenarios
 
-Although the `tox-ansible` plugin does not have functionality specific to molecule, it can be a powerful tool to run `molecule` scenarios across a matrix of Ansible and Python versions.
+Molecule is a first-class test type in `tox-ansible`. When molecule scenarios are detected in your collection, a `molecule-*` environment is automatically added to the test matrix.
 
-This can be accomplished by presenting molecule scenarios as integration tests available through `pytest` using the [pytest-ansible](https://github.com/ansible-community/pytest-ansible) plugin, which is installed when `tox-ansible` is installed.
+### How it works
 
-Assuming the following collection directory structure:
+`tox-ansible` looks for molecule scenarios under `extensions/molecule/` in your collection root. Each subdirectory containing a `molecule.yml` file is treated as a scenario. When at least one scenario is found, a `molecule-py3.14-2.20` environment is added to the matrix (using the latest stable Python and ansible-core versions).
+
+The `molecule` package is automatically installed as a dependency. Additional molecule plugins (e.g., `molecule-plugins[docker]`) can be added via your collection's `requirements.txt` or `test-requirements.txt`.
+
+### Collection directory structure
 
 ```bash
 namespace.name
 ├── extensions
-│   ├── molecule
-│   │   ├── playbook
-│   │   │   ├── create.yml
-│   │   │   ├── converge.yml
-│   │   │   ├── molecule.yml
-│   │   │   └── verify.yml
-│   │   ├── plugins
-│   │   │   ├── create.yml
-│   │   │   ├── converge.yml
-│   │   │   ├── molecule.yml
-│   │   │   └── verify.yml
-│   │   ├── targets
-│   │   │   ├── create.yml
-│   │   │   ├── converge.yml
-│   │   │   ├── molecule.yml
-│   │   │   └── verify.yml
-├── playbooks
-│   └── site.yaml
+│   └── molecule
+│       ├── default
+│       │   ├── converge.yml
+│       │   ├── molecule.yml
+│       │   └── verify.yml
+│       └── another_scenario
+│           ├── converge.yml
+│           ├── molecule.yml
+│           └── verify.yml
 ├── plugins
-│   ├── action
-│   │   └── action_plugin.py
-│   ├── modules
-│   │   └── module.py
+│   └── modules
+│       └── my_module.py
 ├── tests
-│   ├── integration
-│   │   │── targets
-│   │   │   ├── success
-│   │   │   │   └── tasks
-│   │   │   │       └── main.yaml
-│   │   └── test_integration.py
+│   └── integration
+│       └── ...
 ├── pyproject.toml
 └── galaxy.yml
 ```
 
-Individual `molecule` scenarios can be added to the collection's extension directory to test playbooks, roles, and integration targets.
+### Running molecule tests
 
-In order to present each `molecule` scenario as an individual `pytest` test a new `helper` file is added.
+To run molecule tests:
 
-```python
-# tests/integration/test_integration.py
-
-"""Tests for molecule scenarios."""
-from __future__ import absolute_import, division, print_function
-
-from pytest_ansible.molecule import MoleculeScenario
-
-
-def test_integration(molecule_scenario: MoleculeScenario) -> None:
-    """Run molecule for each scenario.
-
-    :param molecule_scenario: The molecule scenario object
-    """
-    proc = molecule_scenario.test()
-    assert proc.returncode == 0
+```bash
+tox -f molecule --ansible
 ```
 
-The `molecule_scenario` fixture parametrizes the `molecule` scenarios found within the collection and creates an individual `pytest` test for each which will be run during any `integration-*` environment.
+To filter the GitHub Actions matrix to only molecule:
 
-This approach provides the flexibility of running the `molecule` scenarios directly with `molecule`, `pytest` or `tox`. Additionally, presented as native `pytest` tests, the `molecule` scenarios should show in the `pytest` test tree in the user's IDE.
+```bash
+tox --ansible --gh-matrix --matrix-scope molecule
+```
+
+### Configuration
+
+By default, molecule environments are auto-discovered (`molecule = "auto"`). You can override this in your configuration:
+
+```toml
+# pyproject.toml
+[tool.tox-ansible]
+molecule = "auto"  # "auto", "true", or "false"
+```
+
+To provide custom commands instead of the default `pytest --molecule` invocation:
+
+```toml
+[tool.tox-ansible]
+molecule_commands = [
+    "molecule test -s default",
+]
+```
+
+See the [Configuration](configuration.md) page for full details.

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -79,19 +79,20 @@ COVERAGE_DEPS = [
 
 # Paths checked for collection requirements files, keyed by test type.
 # From https://github.com/ansible/ansible-compat/blob/main/src/ansible_compat/constants.py#L6-L14
+SHARED_REQUIREMENTS_YML = "tests/requirements.yml"
 TEST_REQUIREMENTS_YML: dict[str, list[str]] = {
     "unit": [
-        "tests/requirements.yml",
+        SHARED_REQUIREMENTS_YML,
         "tests/unit/requirements.yml",
     ],
     "integration": [
-        "tests/requirements.yml",
+        SHARED_REQUIREMENTS_YML,
         "tests/integration/requirements.yml",
     ],
     # Molecule shares integration collection deps during migration; also
     # accepts a dedicated molecule requirements file when collections split.
     "molecule": [
-        "tests/requirements.yml",
+        SHARED_REQUIREMENTS_YML,
         "tests/integration/requirements.yml",
         "tests/molecule/requirements.yml",
     ],

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -46,6 +46,7 @@ ALLOWED_EXTERNALS = [
 ]
 ENV_LIST = """
 galaxy
+molecule-py3.14-2.20
 {integration, sanity, unit}-py3.11-{ 2.19 }
 {integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21}
 {integration, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
@@ -126,6 +127,18 @@ class AnsibleConfigSet(ConfigSet):
             default=False,
             desc="union AAP/cert extras onto the upstream matrix (ADR-001)",
         )
+        self.add_config(
+            "molecule",
+            of_type=str,
+            default="auto",
+            desc="molecule test type: 'auto' (discover), 'true' (force on), 'false' (force off)",
+        )
+        self.add_config(
+            "molecule_commands",
+            of_type=list[str],
+            default=[],
+            desc="custom molecule commands (empty = default pytest --molecule)",
+        )
 
 
 @dataclass
@@ -136,11 +149,15 @@ class AnsibleConfiguration:
         coverage: Enable coverage reporting for unit tests.
         skip: Environment name fragments to skip.
         downstream: When true, union DOWNSTREAM_EXTRA onto ENV_LIST.
+        molecule: Molecule test type mode ("auto", "true", or "false").
+        molecule_commands: Custom molecule commands.
     """
 
     coverage: bool = False
     skip: list[str] = field(default_factory=list)
     downstream: bool = False
+    molecule: str = "auto"
+    molecule_commands: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -204,7 +221,7 @@ def tox_add_option(parser: ToxParser) -> None:
     parser.add_argument(
         "--matrix-scope",
         default="all",
-        choices=["all", "galaxy", "sanity", "integration", "unit"],
+        choices=["all", "galaxy", "molecule", "sanity", "integration", "unit"],
         help="Limit Ansible environments and GitHub matrix output to the selected scope",
     )
 
@@ -289,6 +306,7 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
         or factors[0]
         not in [
             "integration",
+            "molecule",
             "sanity",
             "unit",
         ]
@@ -314,6 +332,8 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
         if coverage_enabled
         else None
     )
+    ansible_config = _load_ansible_config(state)
+    molecule_commands = ansible_config.molecule_commands if test_type == "molecule" else []
 
     conf = AnsibleTestConf(
         allowlist_externals=ALLOWED_EXTERNALS,
@@ -330,6 +350,7 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
             pos_args=pos_args,
             test_type=test_type,
             coverage_config=coverage_config,
+            molecule_commands=molecule_commands,
         ),
         description=desc_for_env(env_conf.name),
         deps=conf_deps(test_type=test_type, coverage_enabled=coverage_enabled),
@@ -420,6 +441,49 @@ def _coerce_bool(value: object, *, default: bool = False) -> bool:
     return default
 
 
+def discover_molecule_scenarios(project_dir: Path) -> bool:
+    """Check if molecule scenarios exist in the collection.
+
+    Looks for subdirectories under ``extensions/molecule/`` that contain
+    a ``molecule.yml`` file.
+
+    Args:
+        project_dir: The project root directory.
+
+    Returns:
+        True if at least one molecule scenario is found.
+    """
+    molecule_dir = project_dir / "extensions" / "molecule"
+    if not molecule_dir.is_dir():
+        return False
+    return any(
+        (scenario / "molecule.yml").is_file()
+        for scenario in molecule_dir.iterdir()
+        if scenario.is_dir()
+    )
+
+
+def _should_include_molecule(
+    molecule_setting: str,
+    project_dir: Path,
+) -> bool:
+    """Determine whether molecule environments should be included.
+
+    Args:
+        molecule_setting: The molecule config value ("auto", "true", or "false").
+        project_dir: The project root directory.
+
+    Returns:
+        True if molecule environments should be included.
+    """
+    if molecule_setting == "true":
+        return True
+    if molecule_setting == "false":
+        return False
+    return discover_molecule_scenarios(project_dir)
+
+
+
 def _load_ansible_config(state: State) -> AnsibleConfiguration:
     """Load tox-ansible configuration using TOML-over-INI precedence.
 
@@ -437,6 +501,8 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
             coverage=_coerce_bool(pyproject_config.get("coverage", False)),
             skip=pyproject_config.get("skip", []),
             downstream=_coerce_bool(pyproject_config.get("downstream", False)),
+            molecule=pyproject_config.get("molecule", "auto"),
+            molecule_commands=pyproject_config.get("molecule_commands", []),
         )
 
     ansible_config = state.conf.get_section_config(
@@ -449,6 +515,8 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
         coverage=ansible_config["coverage"],
         skip=ansible_config["skip"],
         downstream=ansible_config["downstream"],
+        molecule=ansible_config["molecule"],
+        molecule_commands=ansible_config["molecule_commands"],
     )
 
 
@@ -508,7 +576,6 @@ def add_ansible_matrix(state: State, scope: str = "all") -> EnvList:
         logger.warning(msg)
 
     ansible_config = _load_ansible_config(state)
-    skip_list = ansible_config.skip
 
     env_list = StrConvert().to_env_list(ENV_LIST)
     if ansible_config.downstream:
@@ -523,8 +590,10 @@ def add_ansible_matrix(state: State, scope: str = "all") -> EnvList:
     env_list.envs = [
         env
         for env in env_list.envs
-        if _env_in_scope(env, scope) and all(skip not in env for skip in skip_list)
+        if _env_in_scope(env, scope) and all(skip not in env for skip in ansible_config.skip)
     ]
+    if not _should_include_molecule(ansible_config.molecule, project_dir):
+        env_list.envs = [env for env in env_list.envs if not env.startswith("molecule-")]
     env_list.envs = sorted(env_list.envs, key=custom_sort)
     state.conf.core.loaders.insert(
         0,
@@ -740,12 +809,14 @@ def _write_coverage_config(
     return coverage_config
 
 
-def conf_commands(
+def conf_commands(  # noqa: PLR0913
     collection: Collection,
     env_conf: EnvConfigSet,
     pos_args: tuple[str, ...] | None,
     test_type: str,
+    *,
     coverage_config: Path | None = None,
+    molecule_commands: list[str] | None = None,
 ) -> list[str]:
     """Build the commands for the tox environment.
 
@@ -753,8 +824,9 @@ def conf_commands(
         collection: The collection info.
         env_conf: The tox environment configuration object.
         pos_args: Positional arguments passed to tox command.
-        test_type: The test type, either "integration", "unit", or "sanity".
+        test_type: The test type.
         coverage_config: The generated coverage configuration path.
+        molecule_commands: Custom molecule commands from config.
 
     Returns:
         The commands to run.
@@ -764,6 +836,11 @@ def conf_commands(
             pos_args=pos_args,
             test_type=test_type,
             coverage_config=coverage_config,
+        )
+    if test_type == "molecule":
+        return conf_commands_for_molecule(
+            pos_args=pos_args,
+            molecule_commands=molecule_commands,
         )
     if test_type == "sanity":
         return conf_commands_for_sanity(
@@ -809,6 +886,27 @@ def conf_commands_for_integration_unit(
         f"python3 -m pytest{coverage_args} "
         f"--ansible-unit-inject-only{args}{Path()}/tests/{test_type}"
     )
+    return [command]
+
+
+def conf_commands_for_molecule(
+    pos_args: tuple[str, ...] | None,
+    molecule_commands: list[str] | None = None,
+) -> list[str]:
+    """Build the commands for molecule tests.
+
+    Args:
+        pos_args: Positional arguments passed to tox command.
+        molecule_commands: Custom molecule commands from config.
+
+    Returns:
+        The commands to run.
+    """
+    if molecule_commands:
+        return list(molecule_commands)
+
+    args = f" {' '.join(pos_args)} " if pos_args else " "
+    command = f"python3 -m pytest --molecule{args}{Path()}/tests/integration"
     return [command]
 
 
@@ -982,7 +1080,7 @@ def _test_deps(test_type: str, *, coverage_enabled: bool) -> list[str]:
     deps = list(OUR_DEPS)
     if test_type == "unit" and coverage_enabled:
         deps.extend(COVERAGE_DEPS)
-    if test_type == "integration":
+    if test_type in ("integration", "molecule"):
         deps.append("molecule>=26.4.0")
     cwd = Path.cwd()
     for req_file in PYTHON_DEPENDENCY_FILES:
@@ -1009,7 +1107,7 @@ def conf_deps(test_type: str, *, coverage_enabled: bool = False) -> str:
         deps.append("galaxy-importer>=0.4.31")
     else:
         deps.append("ansible-dev-environment>=26.2.0")
-        if test_type in ("integration", "unit"):
+        if test_type in ("integration", "molecule", "unit"):
             deps.extend(_test_deps(test_type, coverage_enabled=coverage_enabled))
     return "\n".join(deps)
 

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -347,9 +347,13 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
         if coverage_enabled
         else None
     )
-    ansible_config = _load_ansible_config(state)
-    molecule_commands = ansible_config.molecule_commands if test_type == "molecule" else []
-    molecule_append = ansible_config.molecule_append if test_type == "molecule" else []
+    if test_type == "molecule":
+        ansible_config = _load_ansible_config(state)
+        molecule_commands = ansible_config.molecule_commands
+        molecule_append = ansible_config.molecule_append
+    else:
+        molecule_commands = []
+        molecule_append = []
 
     conf = AnsibleTestConf(
         allowlist_externals=ALLOWED_EXTERNALS,
@@ -596,7 +600,7 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
         coverage=ansible_config["coverage"],
         skip=ansible_config["skip"],
         downstream=ansible_config["downstream"],
-        molecule=ansible_config["molecule"],
+        molecule=_coerce_molecule_setting(ansible_config["molecule"]),
         molecule_append=ansible_config["molecule_append"],
         molecule_commands=ansible_config["molecule_commands"],
     )

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -88,6 +88,13 @@ TEST_REQUIREMENTS_YML: dict[str, list[str]] = {
         "tests/requirements.yml",
         "tests/integration/requirements.yml",
     ],
+    # Molecule shares integration collection deps during migration; also
+    # accepts a dedicated molecule requirements file when collections split.
+    "molecule": [
+        "tests/requirements.yml",
+        "tests/integration/requirements.yml",
+        "tests/molecule/requirements.yml",
+    ],
 }
 
 PYTHON_DEPENDENCY_FILES: list[str] = [

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -46,11 +46,10 @@ ALLOWED_EXTERNALS = [
 ]
 ENV_LIST = """
 galaxy
-molecule-py3.14-2.20
-{integration, sanity, unit}-py3.11-{ 2.19 }
-{integration, sanity, unit}-py3.12-{2.19, 2.20, 2.21}
-{integration, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
-{integration, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
+{integration, molecule, sanity, unit}-py3.11-{ 2.19 }
+{integration, molecule, sanity, unit}-py3.12-{2.19, 2.20, 2.21}
+{integration, molecule, sanity, unit}-py3.13-{2.19, 2.20, 2.21, milestone, devel}
+{integration, molecule, sanity, unit}-py3.14-{2.20, 2.21, milestone, devel}
 """
 # ^ py314 is NOT supported before 2.20! If is in official metadata of the
 # release branch, is not supported.
@@ -134,10 +133,16 @@ class AnsibleConfigSet(ConfigSet):
             desc="molecule test type: 'auto' (discover), 'true' (force on), 'false' (force off)",
         )
         self.add_config(
+            "molecule_append",
+            of_type=list[str],
+            default=[],
+            desc="extra argv appended to the default 'molecule test --all' command",
+        )
+        self.add_config(
             "molecule_commands",
             of_type=list[str],
             default=[],
-            desc="custom molecule commands (empty = default pytest --molecule)",
+            desc="full replacement molecule commands (ignores default and molecule_append)",
         )
 
 
@@ -150,13 +155,15 @@ class AnsibleConfiguration:
         skip: Environment name fragments to skip.
         downstream: When true, union DOWNSTREAM_EXTRA onto ENV_LIST.
         molecule: Molecule test type mode ("auto", "true", or "false").
-        molecule_commands: Custom molecule commands.
+        molecule_append: Extra argv appended to the default molecule command.
+        molecule_commands: Full-replacement molecule commands.
     """
 
     coverage: bool = False
     skip: list[str] = field(default_factory=list)
     downstream: bool = False
     molecule: str = "auto"
+    molecule_append: list[str] = field(default_factory=list)
     molecule_commands: list[str] = field(default_factory=list)
 
 
@@ -334,6 +341,7 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
     )
     ansible_config = _load_ansible_config(state)
     molecule_commands = ansible_config.molecule_commands if test_type == "molecule" else []
+    molecule_append = ansible_config.molecule_append if test_type == "molecule" else []
 
     conf = AnsibleTestConf(
         allowlist_externals=ALLOWED_EXTERNALS,
@@ -351,6 +359,7 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
             test_type=test_type,
             coverage_config=coverage_config,
             molecule_commands=molecule_commands,
+            molecule_append=molecule_append,
         ),
         description=desc_for_env(env_conf.name),
         deps=conf_deps(test_type=test_type, coverage_enabled=coverage_enabled),
@@ -463,6 +472,32 @@ def discover_molecule_scenarios(project_dir: Path) -> bool:
     )
 
 
+def discover_integration_tests(project_dir: Path) -> bool:
+    """Check if ansible-test or pytest-style integration tests exist.
+
+    Looks for non-empty ``tests/integration/targets/`` (ansible-test) or
+    pytest modules under ``tests/integration/`` (``test_*.py`` / ``*_test.py``).
+
+    Args:
+        project_dir: The project root directory.
+
+    Returns:
+        True if integration test content is found.
+    """
+    targets = project_dir / "tests" / "integration" / "targets"
+    if targets.is_dir() and any(targets.iterdir()):
+        return True
+
+    integration_dir = project_dir / "tests" / "integration"
+    if not integration_dir.is_dir():
+        return False
+
+    return any(
+        path.name.startswith("test_") or path.name.endswith("_test.py")
+        for path in integration_dir.rglob("*.py")
+    )
+
+
 def _should_include_molecule(
     molecule_setting: str,
     project_dir: Path,
@@ -502,6 +537,7 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
             skip=pyproject_config.get("skip", []),
             downstream=_coerce_bool(pyproject_config.get("downstream", False)),
             molecule=pyproject_config.get("molecule", "auto"),
+            molecule_append=pyproject_config.get("molecule_append", []),
             molecule_commands=pyproject_config.get("molecule_commands", []),
         )
 
@@ -516,6 +552,7 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
         skip=ansible_config["skip"],
         downstream=ansible_config["downstream"],
         molecule=ansible_config["molecule"],
+        molecule_append=ansible_config["molecule_append"],
         molecule_commands=ansible_config["molecule_commands"],
     )
 
@@ -594,6 +631,8 @@ def add_ansible_matrix(state: State, scope: str = "all") -> EnvList:
     ]
     if not _should_include_molecule(ansible_config.molecule, project_dir):
         env_list.envs = [env for env in env_list.envs if not env.startswith("molecule-")]
+    if not discover_integration_tests(project_dir):
+        env_list.envs = [env for env in env_list.envs if not env.startswith("integration-")]
     env_list.envs = sorted(env_list.envs, key=custom_sort)
     state.conf.core.loaders.insert(
         0,
@@ -817,6 +856,7 @@ def conf_commands(  # noqa: PLR0913
     *,
     coverage_config: Path | None = None,
     molecule_commands: list[str] | None = None,
+    molecule_append: list[str] | None = None,
 ) -> list[str]:
     """Build the commands for the tox environment.
 
@@ -826,7 +866,8 @@ def conf_commands(  # noqa: PLR0913
         pos_args: Positional arguments passed to tox command.
         test_type: The test type.
         coverage_config: The generated coverage configuration path.
-        molecule_commands: Custom molecule commands from config.
+        molecule_commands: Full-replacement molecule commands from config.
+        molecule_append: Extra argv appended to the default molecule command.
 
     Returns:
         The commands to run.
@@ -841,6 +882,7 @@ def conf_commands(  # noqa: PLR0913
         return conf_commands_for_molecule(
             pos_args=pos_args,
             molecule_commands=molecule_commands,
+            molecule_append=molecule_append,
         )
     if test_type == "sanity":
         return conf_commands_for_sanity(
@@ -892,12 +934,18 @@ def conf_commands_for_integration_unit(
 def conf_commands_for_molecule(
     pos_args: tuple[str, ...] | None,
     molecule_commands: list[str] | None = None,
+    molecule_append: list[str] | None = None,
 ) -> list[str]:
     """Build the commands for molecule tests.
 
+    Default is ``python3 -m molecule test --all``. ``molecule_append`` adds
+    argv after that default. Non-empty ``molecule_commands`` fully replaces the
+    default (and ignores ``molecule_append`` / ``pos_args``).
+
     Args:
         pos_args: Positional arguments passed to tox command.
-        molecule_commands: Custom molecule commands from config.
+        molecule_commands: Full-replacement molecule commands from config.
+        molecule_append: Extra argv appended to the default molecule command.
 
     Returns:
         The commands to run.
@@ -905,9 +953,12 @@ def conf_commands_for_molecule(
     if molecule_commands:
         return list(molecule_commands)
 
-    args = f" {' '.join(pos_args)} " if pos_args else " "
-    command = f"python3 -m pytest --molecule{args}{Path()}/tests/integration"
-    return [command]
+    parts = ["python3", "-m", "molecule", "test", "--all"]
+    if molecule_append:
+        parts.extend(molecule_append)
+    if pos_args:
+        parts.extend(pos_args)
+    return [" ".join(parts)]
 
 
 def conf_commands_for_sanity(

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -457,6 +457,42 @@ def _coerce_bool(value: object, *, default: bool = False) -> bool:
     return default
 
 
+def _coerce_molecule_setting(value: object, *, default: str = "auto") -> str:
+    """Coerce a pyproject ``molecule`` value to ``auto``, ``true``, or ``false``.
+
+    Args:
+        value: Raw value from TOML (bool, int, str) or INI (str).
+        default: Fallback when the value cannot be interpreted.
+
+    Returns:
+        Normalized molecule mode string.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and value in {0, 1}:
+        return "true" if value else "false"
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        modes = {
+            "true": "true",
+            "1": "true",
+            "yes": "true",
+            "on": "true",
+            "false": "false",
+            "0": "false",
+            "no": "false",
+            "off": "false",
+            "auto": "auto",
+            "": "auto",
+        }
+        if normalized in modes:
+            return modes[normalized]
+    logger.warning("Invalid molecule config value %r; using %r", value, default)
+    return default
+
+
 def discover_molecule_scenarios(project_dir: Path) -> bool:
     """Check if molecule scenarios exist in the collection.
 
@@ -525,7 +561,6 @@ def _should_include_molecule(
     return discover_molecule_scenarios(project_dir)
 
 
-
 def _load_ansible_config(state: State) -> AnsibleConfiguration:
     """Load tox-ansible configuration using TOML-over-INI precedence.
 
@@ -543,7 +578,9 @@ def _load_ansible_config(state: State) -> AnsibleConfiguration:
             coverage=_coerce_bool(pyproject_config.get("coverage", False)),
             skip=pyproject_config.get("skip", []),
             downstream=_coerce_bool(pyproject_config.get("downstream", False)),
-            molecule=pyproject_config.get("molecule", "auto"),
+            molecule=_coerce_molecule_setting(
+                pyproject_config.get("molecule", "auto"),
+            ),
             molecule_append=pyproject_config.get("molecule_append", []),
             molecule_commands=pyproject_config.get("molecule_commands", []),
         )

--- a/tests/fixtures/integration/test_ade_workflow/tests/integration/targets/smoke/tasks/main.yml
+++ b/tests/fixtures/integration/test_ade_workflow/tests/integration/targets/smoke/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Smoke
+  ansible.builtin.debug:
+    msg: ok

--- a/tests/fixtures/integration/test_basic/extensions/molecule/default/converge.yml
+++ b/tests/fixtures/integration/test_basic/extensions/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run sample task
+      ansible.builtin.debug:
+        msg: "Converge complete"

--- a/tests/fixtures/integration/test_basic/extensions/molecule/default/molecule.yml
+++ b/tests/fixtures/integration/test_basic/extensions/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+driver:
+  name: delegated
+platforms:
+  - name: instance
+    managed: false

--- a/tests/fixtures/integration/test_basic/extensions/molecule/default/verify.yml
+++ b/tests/fixtures/integration/test_basic/extensions/molecule/default/verify.yml
@@ -1,0 +1,8 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Verify success
+      ansible.builtin.assert:
+        that: true

--- a/tests/fixtures/integration/test_basic/tests/integration/test_placeholder.py
+++ b/tests/fixtures/integration/test_basic/tests/integration/test_placeholder.py
@@ -1,0 +1,6 @@
+"""Placeholder so the basic fixture keeps integration envs under autodetection."""
+
+
+def test_placeholder() -> None:
+    """Minimal pytest integration module."""
+    assert True

--- a/tests/fixtures/integration/test_basic/tests/integration/test_placeholder.py
+++ b/tests/fixtures/integration/test_basic/tests/integration/test_placeholder.py
@@ -3,4 +3,4 @@
 
 def test_placeholder() -> None:
     """Minimal pytest integration module."""
-    assert True
+    pass

--- a/tests/fixtures/integration/test_molecule_disabled/extensions/molecule/default/molecule.yml
+++ b/tests/fixtures/integration/test_molecule_disabled/extensions/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+driver:
+  name: delegated
+platforms:
+  - name: instance
+    managed: false

--- a/tests/fixtures/integration/test_molecule_disabled/galaxy.yml
+++ b/tests/fixtures/integration/test_molecule_disabled/galaxy.yml
@@ -1,0 +1,3 @@
+name: test_col
+namespace: test_ns
+version: 1.0.0

--- a/tests/fixtures/integration/test_molecule_disabled/pyproject.toml
+++ b/tests/fixtures/integration/test_molecule_disabled/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.tox]
+requires = ["tox>=4.2"]
+
+[tool.tox-ansible]
+molecule = "false"

--- a/tests/fixtures/integration/test_pyproject_config/tests/integration/targets/smoke/tasks/main.yml
+++ b/tests/fixtures/integration/test_pyproject_config/tests/integration/targets/smoke/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Smoke
+  ansible.builtin.debug:
+    msg: ok

--- a/tests/fixtures/integration/test_user_provided/tests/integration/targets/smoke/tasks/main.yml
+++ b/tests/fixtures/integration/test_user_provided/tests/integration/targets/smoke/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Smoke
+  ansible.builtin.debug:
+    msg: ok

--- a/tests/fixtures/unit/test_type/tests/integration/targets/smoke/tasks/main.yml
+++ b/tests/fixtures/unit/test_type/tests/integration/targets/smoke/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Smoke
+  ansible.builtin.debug:
+    msg: ok

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -33,6 +33,7 @@ def test_ansible_environments(module_fixture_dir: Path, tox_bin: Path) -> None:
         print(exc.stderr)
         pytest.fail(exc.stderr)
     assert "integration" in proc.stdout
+    assert "molecule" in proc.stdout
     assert "sanity" in proc.stdout
     assert "unit" in proc.stdout
 

--- a/tests/integration/test_molecule_disabled.py
+++ b/tests/integration/test_molecule_disabled.py
@@ -1,0 +1,50 @@
+"""Integration tests for molecule = false configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_molecule_disabled(
+    module_fixture_dir: Path,
+    tox_bin: Path,
+) -> None:
+    """Validate that molecule=false suppresses molecule envs even with scenarios present.
+
+    The fixture has extensions/molecule/default/molecule.yml but pyproject.toml
+    sets molecule = "false", so no molecule environments should appear.
+
+    Args:
+        module_fixture_dir: pytest fixture for module fixture directory
+        tox_bin: pytest fixture for tox binary
+    """
+    try:
+        proc = subprocess.run(
+            [tox_bin, "list", "--ansible", "--root", str(module_fixture_dir)],
+            capture_output=True,
+            cwd=str(module_fixture_dir),
+            text=True,
+            check=True,
+            shell=False,
+            env=os.environ,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(exc.stdout)
+        print(exc.stderr)
+        pytest.fail(exc.stderr)
+
+    env_names = proc.stdout.strip().splitlines()
+    for name in env_names:
+        assert "molecule" not in name, f"molecule should be disabled: {name}"
+    assert any("unit" in name for name in env_names)
+    assert any("sanity" in name for name in env_names)
+    assert any("integration" in name for name in env_names)

--- a/tests/integration/test_molecule_disabled.py
+++ b/tests/integration/test_molecule_disabled.py
@@ -45,6 +45,6 @@ def test_molecule_disabled(
     env_names = proc.stdout.strip().splitlines()
     for name in env_names:
         assert "molecule" not in name, f"molecule should be disabled: {name}"
+        assert not name.startswith("integration-"), f"no integration content: {name}"
     assert any("unit" in name for name in env_names)
     assert any("sanity" in name for name in env_names)
-    assert any("integration" in name for name in env_names)

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -13,6 +13,7 @@ import pytest
 
 from tox.config.cli.parse import Options
 from tox.config.cli.parser import Parsed
+from tox.config.loader.memory import MemoryLoader
 from tox.config.main import Config
 from tox.config.source import discover_source
 from tox.report import ToxHandler
@@ -29,6 +30,7 @@ from tox_ansible.plugin import (
     conf_deps,
     discover_integration_tests,
     discover_molecule_scenarios,
+    tox_add_env_config,
 )
 
 
@@ -481,6 +483,108 @@ def test_add_ansible_matrix_molecule_auto_not_found(
 
     env_list = add_ansible_matrix(state)
     assert not any("molecule" in name for name in env_list.envs)
+
+
+def test_add_ansible_matrix_molecule_ini_true_case_insensitive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test INI molecule=True is coerced and forces molecule envs on.
+
+    Without coercion, tox would preserve ``True`` and auto-discovery would
+    incorrectly omit molecule environments when no scenarios exist.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file.write_text("[ansible]\nmolecule = True\n")
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert any(name.startswith("molecule-") for name in env_list.envs)
+
+
+def test_tox_add_env_config_molecule_loads_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test tox_add_env_config loads molecule_append for molecule envs.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file.write_text(
+        "[ansible]\nmolecule = true\nmolecule_append =\n    --workers\n    4\n",
+    )
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    env_conf = Config.make(
+        parsed=parsed,
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("molecule-py3.14-2.20")
+
+    env_conf.add_config(
+        keys=["env_dir", "envdir"],
+        of_type=Path,
+        default=tmp_path,
+        desc="",
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    tox_add_env_config(env_conf, state)
+
+    assert isinstance(env_conf.loaders[0], MemoryLoader)
+    commands = env_conf.loaders[0].raw["commands"]
+    assert any("--workers" in cmd and "4" in cmd for cmd in commands)
 
 
 def test_add_ansible_matrix_molecule_pyproject_true(

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -177,6 +177,59 @@ def test_commands_pre_molecule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     assert "--acv stable-2.20 --no-seed" in result[0]
 
 
+def test_commands_pre_molecule_with_requirements(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test molecule pre-commands install shared and molecule requirements.yml.
+
+    Args:
+        monkeypatch: Pytest fixture.
+        tmp_path: Pytest fixture.
+    """
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "requirements.yml").write_text("collections: []")
+    (tmp_path / "tests" / "integration").mkdir()
+    (tmp_path / "tests" / "integration" / "requirements.yml").write_text("collections: []")
+    (tmp_path / "tests" / "molecule").mkdir()
+    (tmp_path / "tests" / "molecule" / "requirements.yml").write_text("collections: []")
+
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("molecule-py3.14-2.20")
+
+    conf.add_config(
+        keys=["env_dir", "envdir"],
+        of_type=Path,
+        default=tmp_path,
+        desc="",
+    )
+
+    result = conf_commands_pre(
+        env_conf=conf,
+        collection=Collection(name="test", namespace="test", version="1.0.0"),
+        test_type="molecule",
+        ansible_version="2.20",
+    )
+    expected_commands = 8
+    assert len(result) == expected_commands, result
+    assert result[3] == "echo ::group::Install collection requirements with ade"
+    assert "ade install -r tests/requirements.yml" in result[4]
+    assert "ade install -r tests/integration/requirements.yml" in result[5]
+    assert "ade install -r tests/molecule/requirements.yml" in result[6]
+    assert result[7] == "echo ::endgroup::"
+
+
 def test_discover_molecule_scenarios_found(tmp_path: Path) -> None:
     """Test molecule discovery when scenarios exist.
 

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest  # noqa: TC002
+import pytest
 
 from tox.config.cli.parse import Options
 from tox.config.cli.parser import Parsed
@@ -20,6 +20,7 @@ from tox.session.state import State
 
 from tox_ansible.plugin import (
     Collection,
+    _coerce_molecule_setting,
     _should_include_molecule,
     add_ansible_matrix,
     conf_commands,
@@ -314,6 +315,72 @@ def test_should_include_molecule_auto_without_scenarios(tmp_path: Path) -> None:
         tmp_path: Pytest fixture.
     """
     assert _should_include_molecule("auto", tmp_path) is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    (
+        (True, "true"),
+        (False, "false"),
+        (1, "true"),
+        (0, "false"),
+        ("true", "true"),
+        ("FALSE", "false"),
+        ("auto", "auto"),
+        (None, "auto"),
+    ),
+)
+def test_coerce_molecule_setting(raw: object, expected: str) -> None:
+    """Test TOML-friendly coercion for molecule config values.
+
+    Args:
+        raw: Raw config value from TOML.
+        expected: Normalized molecule mode string.
+    """
+    assert _coerce_molecule_setting(raw) == expected
+
+
+def test_add_ansible_matrix_molecule_pyproject_bool_true(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test molecule envs included when pyproject uses a TOML boolean true.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.tox-ansible]\nmolecule = true\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert any("molecule" in name for name in env_list.envs)
 
 
 def test_add_ansible_matrix_molecule_auto_found(

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -340,6 +340,19 @@ def test_coerce_molecule_setting(raw: object, expected: str) -> None:
     assert _coerce_molecule_setting(raw) == expected
 
 
+def test_coerce_molecule_setting_invalid(caplog: pytest.LogCaptureFixture) -> None:
+    """Test invalid molecule values fall back to auto with a warning.
+
+    Args:
+        caplog: Pytest fixture.
+    """
+    with caplog.at_level("WARNING"):
+        assert _coerce_molecule_setting("maybe") == "auto"
+        assert _coerce_molecule_setting(2) == "auto"
+        assert _coerce_molecule_setting(["true"]) == "auto"
+    assert "Invalid molecule config value" in caplog.text
+
+
 def test_add_ansible_matrix_molecule_pyproject_bool_true(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -26,6 +26,7 @@ from tox_ansible.plugin import (
     conf_commands_for_molecule,
     conf_commands_pre,
     conf_deps,
+    discover_integration_tests,
     discover_molecule_scenarios,
 )
 
@@ -53,15 +54,32 @@ def test_conf_commands_molecule() -> None:
     """Test default molecule command generation."""
     result = conf_commands_for_molecule(pos_args=None)
     assert len(result) == 1
-    assert result[0] == "python3 -m pytest --molecule ./tests/integration"
+    assert result[0] == "python3 -m molecule test --all"
 
 
 def test_conf_commands_molecule_with_args() -> None:
     """Test molecule command generation with pos_args."""
     result = conf_commands_for_molecule(pos_args=("--verbose", "-x"))
     assert len(result) == 1
-    assert "--verbose -x" in result[0]
-    assert "pytest --molecule" in result[0]
+    assert result[0] == "python3 -m molecule test --all --verbose -x"
+
+
+def test_conf_commands_molecule_append() -> None:
+    """Test molecule_append adds argv after the default command."""
+    result = conf_commands_for_molecule(
+        pos_args=None,
+        molecule_append=["--workers", "4"],
+    )
+    assert result == ["python3 -m molecule test --all --workers 4"]
+
+
+def test_conf_commands_molecule_append_and_pos_args() -> None:
+    """Test molecule_append and tox pos_args are both applied."""
+    result = conf_commands_for_molecule(
+        pos_args=("--shared-state",),
+        molecule_append=["--workers", "2"],
+    )
+    assert result == ["python3 -m molecule test --all --workers 2 --shared-state"]
 
 
 def test_conf_commands_molecule_custom() -> None:
@@ -71,10 +89,14 @@ def test_conf_commands_molecule_custom() -> None:
     assert result == custom
 
 
-def test_conf_commands_molecule_custom_ignores_pos_args() -> None:
-    """Test that custom molecule_commands are used as-is, ignoring pos_args."""
+def test_conf_commands_molecule_custom_ignores_append_and_pos_args() -> None:
+    """Test that molecule_commands fully replaces default/append/pos_args."""
     custom = ["molecule test"]
-    result = conf_commands_for_molecule(pos_args=("--verbose",), molecule_commands=custom)
+    result = conf_commands_for_molecule(
+        pos_args=("--verbose",),
+        molecule_commands=custom,
+        molecule_append=["--workers", "4"],
+    )
     assert result == custom
 
 
@@ -101,8 +123,7 @@ def test_conf_commands_molecule_via_conf_commands(tmp_path: Path) -> None:
         test_type="molecule",
         pos_args=None,
     )
-    assert len(result) == 1
-    assert "pytest --molecule" in result[0]
+    assert result == ["python3 -m molecule test --all"]
 
 
 def test_conf_deps_molecule(tmp_path: Path) -> None:
@@ -283,6 +304,10 @@ def test_add_ansible_matrix_molecule_auto_found(
 
     env_list = add_ansible_matrix(state)
     assert any("molecule" in name for name in env_list.envs)
+    molecule_envs = [name for name in env_list.envs if name.startswith("molecule-")]
+    assert len(molecule_envs) > 1
+    assert "molecule-py3.12-2.19" in molecule_envs
+    assert "molecule-py3.14-2.20" in molecule_envs
 
 
 def test_add_ansible_matrix_molecule_auto_not_found(
@@ -412,3 +437,77 @@ def test_add_ansible_matrix_molecule_pyproject_false(
 
     env_list = add_ansible_matrix(state)
     assert not any("molecule" in name for name in env_list.envs)
+
+
+def test_discover_integration_tests_targets(tmp_path: Path) -> None:
+    """Test integration discovery via ansible-test targets.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    target = tmp_path / "tests" / "integration" / "targets" / "ping"
+    target.mkdir(parents=True)
+    (target / "tasks").mkdir()
+    assert discover_integration_tests(tmp_path) is True
+
+
+def test_discover_integration_tests_pytest(tmp_path: Path) -> None:
+    """Test integration discovery via pytest modules.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    integration = tmp_path / "tests" / "integration"
+    integration.mkdir(parents=True)
+    (integration / "test_smoke.py").write_text("def test_smoke():\n    assert True\n")
+    assert discover_integration_tests(tmp_path) is True
+
+
+def test_discover_integration_tests_missing(tmp_path: Path) -> None:
+    """Test integration discovery when no content exists.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    assert discover_integration_tests(tmp_path) is False
+
+
+def test_add_ansible_matrix_strips_integration_without_tests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test integration envs are omitted when no integration content exists.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file.write_text("[ansible]\n")
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert not any(name.startswith("integration-") for name in env_list.envs)
+    assert any(name.startswith("unit-") for name in env_list.envs)

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -1,0 +1,414 @@
+"""Unit tests for molecule test type support."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest  # noqa: TC002
+
+from tox.config.cli.parse import Options
+from tox.config.cli.parser import Parsed
+from tox.config.main import Config
+from tox.config.source import discover_source
+from tox.report import ToxHandler
+from tox.session.state import State
+
+from tox_ansible.plugin import (
+    Collection,
+    _should_include_molecule,
+    add_ansible_matrix,
+    conf_commands,
+    conf_commands_for_molecule,
+    conf_commands_pre,
+    conf_deps,
+    discover_molecule_scenarios,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Generator[None, None, None]:
+    """Changes working directory and returns to previous on exit.
+
+    Args:
+        path: Path object.
+    """
+    prev_cwd = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+def test_conf_commands_molecule() -> None:
+    """Test default molecule command generation."""
+    result = conf_commands_for_molecule(pos_args=None)
+    assert len(result) == 1
+    assert result[0] == "python3 -m pytest --molecule ./tests/integration"
+
+
+def test_conf_commands_molecule_with_args() -> None:
+    """Test molecule command generation with pos_args."""
+    result = conf_commands_for_molecule(pos_args=("--verbose", "-x"))
+    assert len(result) == 1
+    assert "--verbose -x" in result[0]
+    assert "pytest --molecule" in result[0]
+
+
+def test_conf_commands_molecule_custom() -> None:
+    """Test molecule command generation with custom molecule_commands."""
+    custom = ["molecule test -s default", "molecule verify"]
+    result = conf_commands_for_molecule(pos_args=None, molecule_commands=custom)
+    assert result == custom
+
+
+def test_conf_commands_molecule_custom_ignores_pos_args() -> None:
+    """Test that custom molecule_commands are used as-is, ignoring pos_args."""
+    custom = ["molecule test"]
+    result = conf_commands_for_molecule(pos_args=("--verbose",), molecule_commands=custom)
+    assert result == custom
+
+
+def test_conf_commands_molecule_via_conf_commands(tmp_path: Path) -> None:
+    """Test molecule commands through the conf_commands dispatcher.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("molecule-py3.14-2.20")
+
+    result = conf_commands(
+        env_conf=conf,
+        collection=Collection(name="test", namespace="test", version="1.0.0"),
+        test_type="molecule",
+        pos_args=None,
+    )
+    assert len(result) == 1
+    assert "pytest --molecule" in result[0]
+
+
+def test_conf_deps_molecule(tmp_path: Path) -> None:
+    """Test the conf_deps function for molecule tests.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    with working_directory(tmp_path):
+        result = conf_deps(test_type="molecule")
+        assert "ansible-dev-environment>=26.2.0" in result
+        assert "molecule>=26.4.0" in result
+        assert "pytest" in result
+
+
+def test_commands_pre_molecule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test pre-command generation for molecule uses editable ade install.
+
+    Args:
+        monkeypatch: Pytest fixture.
+        tmp_path: Pytest fixture.
+    """
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    source = discover_source(ini_file, None)
+
+    conf = Config.make(
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        pos_args=[],
+        source=source,
+        extra_envs=[],
+    ).get_env("molecule-py3.14-2.20")
+
+    conf.add_config(
+        keys=["env_dir", "envdir"],
+        of_type=Path,
+        default=tmp_path,
+        desc="",
+    )
+
+    result = conf_commands_pre(
+        env_conf=conf,
+        collection=Collection(name="test", namespace="test", version="1.0.0"),
+        test_type="molecule",
+        ansible_version="2.20",
+    )
+    assert len(result) == 1
+    assert "ade install -e" in result[0]
+    assert "--acv stable-2.20 --no-seed" in result[0]
+
+
+def test_discover_molecule_scenarios_found(tmp_path: Path) -> None:
+    """Test molecule discovery when scenarios exist.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "molecule.yml").write_text("---\ndriver:\n  name: delegated\n")
+    assert discover_molecule_scenarios(tmp_path) is True
+
+
+def test_discover_molecule_scenarios_not_found(tmp_path: Path) -> None:
+    """Test molecule discovery when no scenarios exist.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    assert discover_molecule_scenarios(tmp_path) is False
+
+
+def test_discover_molecule_scenarios_empty_dir(tmp_path: Path) -> None:
+    """Test molecule discovery with extensions/molecule/ but no scenario dirs.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    molecule_dir = tmp_path / "extensions" / "molecule"
+    molecule_dir.mkdir(parents=True)
+    assert discover_molecule_scenarios(tmp_path) is False
+
+
+def test_discover_molecule_scenarios_no_molecule_yml(tmp_path: Path) -> None:
+    """Test molecule discovery when scenario dir exists but lacks molecule.yml.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "converge.yml").write_text("---\n")
+    assert discover_molecule_scenarios(tmp_path) is False
+
+
+def test_should_include_molecule_true(tmp_path: Path) -> None:
+    """Test _should_include_molecule with explicit true.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    assert _should_include_molecule("true", tmp_path) is True
+
+
+def test_should_include_molecule_false(tmp_path: Path) -> None:
+    """Test _should_include_molecule with explicit false.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "molecule.yml").touch()
+    assert _should_include_molecule("false", tmp_path) is False
+
+
+def test_should_include_molecule_auto_with_scenarios(tmp_path: Path) -> None:
+    """Test _should_include_molecule auto-discovers scenarios.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "molecule.yml").touch()
+    assert _should_include_molecule("auto", tmp_path) is True
+
+
+def test_should_include_molecule_auto_without_scenarios(tmp_path: Path) -> None:
+    """Test _should_include_molecule returns false when no scenarios.
+
+    Args:
+        tmp_path: Pytest fixture.
+    """
+    assert _should_include_molecule("auto", tmp_path) is False
+
+
+def test_add_ansible_matrix_molecule_auto_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test molecule envs included when scenarios are discovered.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file.write_text("[ansible]\n")
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "molecule.yml").touch()
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert any("molecule" in name for name in env_list.envs)
+
+
+def test_add_ansible_matrix_molecule_auto_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test molecule envs excluded when no scenarios discovered.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox-ansible.ini"
+    ini_file.write_text("[ansible]\n")
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert not any("molecule" in name for name in env_list.envs)
+
+
+def test_add_ansible_matrix_molecule_pyproject_true(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test molecule envs included via pyproject.toml molecule=true.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tox-ansible]\nmolecule = "true"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert any("molecule" in name for name in env_list.envs)
+
+
+def test_add_ansible_matrix_molecule_pyproject_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test molecule envs excluded via pyproject.toml molecule=false.
+
+    Args:
+        tmp_path: Pytest fixture.
+        monkeypatch: Pytest fixture.
+    """
+    ini_file = tmp_path / "tox.ini"
+    ini_file.touch()
+    (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
+    scenario_dir = tmp_path / "extensions" / "molecule" / "default"
+    scenario_dir.mkdir(parents=True)
+    (scenario_dir / "molecule.yml").touch()
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tox-ansible]\nmolecule = "false"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    source = discover_source(ini_file, None)
+    parsed = Parsed(
+        work_dir=tmp_path,
+        override=[],
+        config_file=ini_file,
+        root_dir=tmp_path,
+        ansible=True,
+    )
+
+    output = io.BytesIO()
+    wrapper = io.TextIOWrapper(buffer=output, encoding="utf-8", line_buffering=True)
+    state = State(
+        options=Options(
+            parsed=parsed,
+            pos_args="",
+            source=source,
+            cmd_handlers={},
+            log_handler=ToxHandler(level=0, is_colored=False, out_err=(wrapper, wrapper)),
+        ),
+        args=[],
+    )
+
+    env_list = add_ansible_matrix(state)
+    assert not any("molecule" in name for name in env_list.envs)


### PR DESCRIPTION
## Summary

Adds the **orchestration layer** for the [Unified Collection Testing Strategy](https://github.com/ansible/handbook/pull/1520): a first-class `molecule` test type so collections can run migrated integration scenarios through tox locally and in CI — the same way they already run unit/sanity/integration.

Consumes layouts produced by [ansible/ansible-creator#623](https://github.com/ansible/ansible-creator/pull/623) (`ansible-creator migrate molecule`). Validated against the pilot collection [ansible-collections/ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444), which pins this branch until merge:

- Fork: [cidrblock/tox-ansible@molecule-test-type](https://github.com/cidrblock/tox-ansible/tree/molecule-test-type)
- CI proof: [ansible.utils workflow dispatch](https://github.com/ansible-collections/ansible.utils/actions/workflows/tests.yml) on branch `migrate-integration-to-molecule`

### What changed

- `molecule` / `molecule_append` / `molecule_commands` config (INI `[ansible]` and TOML `[tool.tox-ansible]`).
- Default command: `python3 -m molecule test --all`; `molecule_append` for extra argv; `molecule_commands` for full replace.
- Autodetect scenarios (`extensions/molecule/*/molecule.yml`); omit `integration-*` envs when neither ansible-test targets nor pytest integration modules exist.
- `--matrix-scope molecule` support (compatible with #583 scope filtering).
- Envlist autodetection: `molecule=auto|true|false` (TOML bool/int coerced).
- Molecule `commands_pre` installs collection requirements via ADE (`tests/requirements.yml`, `tests/integration/requirements.yml`, optional `tests/molecule/requirements.yml`).
- Unit + integration fixtures/tests; docs updated.

### Follow-ups addressed on this PR

- Install collection `requirements.yml` for `molecule-*` envs
- Coerce TOML `molecule = true/false` (and int 0/1) instead of silently falling through to auto
- SonarCloud S1192: shared `SHARED_REQUIREMENTS_YML` constant (`c51a3e2`)
- Codecov: cover invalid `molecule` coercion fallback warning path
- Coerce `molecule` from INI (`True` → `true`) same as TOML
- Load molecule append/commands config only for molecule envs

### Story / merge order

1. Strategy: [handbook#1520](https://github.com/ansible/handbook/pull/1520)
2. [ansible-creator#623](https://github.com/ansible/ansible-creator/pull/623) — generates `extensions/molecule/` layout
3. **This PR** — tox/CI runner for that layout
4. [ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444) — drop fork pin + enable content-actions molecule scope when ready

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e py` passes
- [x] Docs updated
- [x] Rebased onto `main` including #583 matrix-scope
- [ ] CI / SonarCloud green after S1192 fix
- [ ] Validate against [ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444) molecule matrix (workflow dispatch on `migrate-integration-to-molecule`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class Molecule scenario support, including automatic scenario discovery and dedicated test environments.
  * Added configuration options to enable or disable Molecule and customize its commands.
  * Added support for selecting Molecule in matrix scopes.
  * Integration environments are now omitted when no integration tests are detected.

* **Documentation**
  * Updated configuration and user guides with Molecule setup, discovery, commands, dependencies, and environment behavior.
  * Reformatted the documented test command list.

* **Tests**
  * Added coverage for Molecule execution, configuration, discovery, matrix generation, and integration detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
