### PR TITLE
chore(docs): fix expression injection in CI/CD pipeline example

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -200,8 +200,10 @@ jobs:
     steps:
       # ...
       - name: Run tox environment ${{ matrix.env.name }}
+        env:
+          TOX_ENV: ${{ matrix.env.name }}
         run: |
-          tox --ansible --conf tox-ansible.ini -e ${{ matrix.env.name }}
+          tox --ansible --conf tox-ansible.ini -e "$TOX_ENV"
 ```
 
 ## Skip functionality


### PR DESCRIPTION
## Summary

- `${{ matrix.env.name }}` was interpolated directly into the `run:` shell script in the CI/CD pipeline example, which is subject to an expression injection vulnerability.
- Fixed by passing the value through an `env:` variable (`TOX_ENV`) instead, so the shell never receives an unescaped expression.

## Details

GitHub Actions evaluates `${{ ... }}` expressions before the shell runs. When the result is interpolated directly into a `run:` block, an attacker who can influence the matrix value (e.g. via a branch name or other user-controlled input) could inject arbitrary shell commands. Passing the value through `env:` ensures it is treated as data, not code.

This was flagged via [zizmor](https://github.com/woodruffw/zizmor) v1.29.0 (`template-injection`, confidence: High).

## Test plan

- [ ] Verify the updated workflow snippet renders correctly in the docs
- [x] Confirm `zizmor` no longer flags `template-injection` on the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)