### PR TITLE
fix(tests): add result_json to Parsed() calls for tox 4.59 compat

### DIFF
--- a/tests/unit/test_downstream_matrix.py
+++ b/tests/unit/test_downstream_matrix.py
@@ -51,6 +51,7 @@ def _make_state(config_file: Path) -> State:
         config_file=config_file,
         root_dir=config_file.parent,
         ansible=True,
+    result_json=None,
     )
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)

--- a/tests/unit/test_downstream_matrix.py
+++ b/tests/unit/test_downstream_matrix.py
@@ -51,7 +51,7 @@ def _make_state(config_file: Path) -> State:
         config_file=config_file,
         root_dir=config_file.parent,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -47,6 +47,12 @@ if typing.TYPE_CHECKING:
     from collections.abc import Generator
 
 
+def _parsed(**kwargs: object) -> Parsed:
+    kwargs.setdefault("override", [])
+    kwargs.setdefault("result_json", None)
+    return Parsed(**kwargs)
+
+
 @pytest.mark.parametrize(
     "scope",
     ("all", "galaxy", "integration", "sanity", "unit"),
@@ -81,13 +87,7 @@ def test_commands_pre_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -129,13 +129,7 @@ def test_commands_pre_sanity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -188,13 +182,7 @@ def test_commands_pre_devel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -233,13 +221,7 @@ def test_commands_pre_milestone(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -286,13 +268,7 @@ def test_commands_pre_unit_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -342,13 +318,7 @@ def test_commands_pre_integration_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -394,13 +364,7 @@ def test_commands_pre_unit_partial_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -446,13 +410,7 @@ def test_commands_pre_sanity_ignores_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -494,13 +452,7 @@ def test_commands_pre_no_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -672,13 +624,7 @@ def test_conf_commands_unit(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -704,13 +650,7 @@ def test_conf_commands_unit_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -744,13 +684,7 @@ def test_conf_commands_sanity(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -785,13 +719,7 @@ def test_conf_commands_integration(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -817,13 +745,7 @@ def test_conf_commands_integration_ignores_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -852,13 +774,7 @@ def test_conf_commands_invalid(tmp_path: Path, caplog: pytest.LogCaptureFixture)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -977,13 +893,7 @@ def test_conf_setenv_collections_path(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1012,13 +922,7 @@ def test_conf_setenv_galaxy(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=ini_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1057,14 +961,7 @@ def test_tox_add_env_config_valid(
         work_dir.mkdir(exist_ok=True)
     monkeypatch.chdir(tmp_path)
     source = discover_source(ini_file, None)
-    parsed = Parsed(
-        work_dir=work_dir,
-        override=[],
-        config_file=ini_file,
-        root_dir=tmp_path,
-        ansible=True,
-        result_json=None,
-    )
+    parsed = _parsed(work_dir=work_dir, config_file=ini_file, root_dir=tmp_path, ansible=True)
 
     env_conf = Config.make(
         parsed=parsed,
@@ -1119,14 +1016,7 @@ def test_tox_add_env_config_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test")
     monkeypatch.chdir(tmp_path)
     source = discover_source(ini_file, None)
-    parsed = Parsed(
-        work_dir=tmp_path,
-        override=[],
-        config_file=ini_file,
-        root_dir=tmp_path,
-        ansible=True,
-        result_json=None,
-    )
+    parsed = _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path, ansible=True)
 
     env_conf = Config.make(
         parsed=parsed,
@@ -1176,14 +1066,7 @@ def test_tox_add_env_config_no_base_python(
     (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
     monkeypatch.chdir(tmp_path)
     source = discover_source(ini_file, None)
-    parsed = Parsed(
-        work_dir=tmp_path,
-        override=[],
-        config_file=ini_file,
-        root_dir=tmp_path,
-        ansible=True,
-        result_json=None,
-    )
+    parsed = _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path, ansible=True)
 
     env_conf = Config.make(
         parsed=parsed,
@@ -1263,14 +1146,7 @@ def test_add_ansible_matrix_pyproject(
     )
     monkeypatch.chdir(tmp_path)
     source = discover_source(ini_file, None)
-    parsed = Parsed(
-        work_dir=tmp_path,
-        override=[],
-        config_file=ini_file,
-        root_dir=tmp_path,
-        ansible=True,
-        result_json=None,
-    )
+    parsed = _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path, ansible=True)
 
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(
@@ -1315,14 +1191,7 @@ def test_add_ansible_matrix_ini_fallback(
     (tmp_path / "galaxy.yml").write_text("namespace: test\nname: test\nversion: 1.0.0")
     monkeypatch.chdir(tmp_path)
     source = discover_source(ini_file, None)
-    parsed = Parsed(
-        work_dir=tmp_path,
-        override=[],
-        config_file=ini_file,
-        root_dir=tmp_path,
-        ansible=True,
-        result_json=None,
-    )
+    parsed = _parsed(work_dir=tmp_path, config_file=ini_file, root_dir=tmp_path, ansible=True)
 
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(
@@ -1435,14 +1304,12 @@ def _make_state(
         The configured tox state.
     """
     source = discover_source(config_file, None)
-    parsed = Parsed(
+    parsed = _parsed(
         work_dir=config_file.parent / ".tox",
-        override=[],
         config_file=config_file,
         root_dir=config_file.parent,
         ansible=True,
         coverage=coverage,
-        result_json=None,
     )
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)
@@ -1526,13 +1393,7 @@ def test_collection_install_path(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(
-            work_dir=tmp_path,
-            override=[],
-            config_file=config_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path, config_file=config_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1564,13 +1425,7 @@ def test_write_coverage_config(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(
-            work_dir=tmp_path / ".tox",
-            override=[],
-            config_file=config_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path / ".tox", config_file=config_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1614,13 +1469,7 @@ def test_write_coverage_config_isolates_data_by_environment(tmp_path: Path) -> N
     config_file.touch()
     source = discover_source(config_file, None)
     config = Config.make(
-        Parsed(
-            work_dir=tmp_path / ".tox",
-            override=[],
-            config_file=config_file,
-            root_dir=tmp_path,
-            result_json=None,
-        ),
+        _parsed(work_dir=tmp_path / ".tox", config_file=config_file, root_dir=tmp_path),
         pos_args=[],
         source=source,
         extra_envs=[],

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -81,7 +81,13 @@ def test_commands_pre_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -123,7 +129,13 @@ def test_commands_pre_sanity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -176,7 +188,13 @@ def test_commands_pre_devel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -215,7 +233,13 @@ def test_commands_pre_milestone(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -262,7 +286,13 @@ def test_commands_pre_unit_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -312,7 +342,13 @@ def test_commands_pre_integration_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -358,7 +394,13 @@ def test_commands_pre_unit_partial_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -404,7 +446,13 @@ def test_commands_pre_sanity_ignores_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -446,7 +494,13 @@ def test_commands_pre_no_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -618,7 +672,13 @@ def test_conf_commands_unit(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -644,7 +704,13 @@ def test_conf_commands_unit_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -678,7 +744,13 @@ def test_conf_commands_sanity(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -713,7 +785,13 @@ def test_conf_commands_integration(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -739,7 +817,13 @@ def test_conf_commands_integration_ignores_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -768,7 +852,13 @@ def test_conf_commands_invalid(tmp_path: Path, caplog: pytest.LogCaptureFixture)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -887,7 +977,13 @@ def test_conf_setenv_collections_path(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -916,7 +1012,13 @@ def test_conf_setenv_galaxy(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -961,7 +1063,7 @@ def test_tox_add_env_config_valid(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     env_conf = Config.make(
@@ -1023,7 +1125,7 @@ def test_tox_add_env_config_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     env_conf = Config.make(
@@ -1080,7 +1182,7 @@ def test_tox_add_env_config_no_base_python(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     env_conf = Config.make(
@@ -1167,7 +1269,7 @@ def test_add_ansible_matrix_pyproject(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -1219,7 +1321,7 @@ def test_add_ansible_matrix_ini_fallback(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -1340,7 +1442,7 @@ def _make_state(
         root_dir=config_file.parent,
         ansible=True,
         coverage=coverage,
-    result_json=None,
+        result_json=None,
     )
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)
@@ -1424,7 +1526,13 @@ def test_collection_install_path(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=config_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1456,7 +1564,13 @@ def test_write_coverage_config(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path / ".tox",
+            override=[],
+            config_file=config_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1500,7 +1614,13 @@ def test_write_coverage_config_isolates_data_by_environment(tmp_path: Path) -> N
     config_file.touch()
     source = discover_source(config_file, None)
     config = Config.make(
-        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path / ".tox",
+            override=[],
+            config_file=config_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -81,7 +81,7 @@ def test_commands_pre_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -123,7 +123,7 @@ def test_commands_pre_sanity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -176,7 +176,7 @@ def test_commands_pre_devel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -215,7 +215,7 @@ def test_commands_pre_milestone(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -262,7 +262,7 @@ def test_commands_pre_unit_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -312,7 +312,7 @@ def test_commands_pre_integration_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -358,7 +358,7 @@ def test_commands_pre_unit_partial_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -404,7 +404,7 @@ def test_commands_pre_sanity_ignores_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -446,7 +446,7 @@ def test_commands_pre_no_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -618,7 +618,7 @@ def test_conf_commands_unit(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -644,7 +644,7 @@ def test_conf_commands_unit_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -678,7 +678,7 @@ def test_conf_commands_sanity(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -713,7 +713,7 @@ def test_conf_commands_integration(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -739,7 +739,7 @@ def test_conf_commands_integration_ignores_coverage(tmp_path: Path) -> None:
     ini_file.touch()
     source = discover_source(ini_file, None)
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -768,7 +768,7 @@ def test_conf_commands_invalid(tmp_path: Path, caplog: pytest.LogCaptureFixture)
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -887,7 +887,7 @@ def test_conf_setenv_collections_path(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -916,7 +916,7 @@ def test_conf_setenv_galaxy(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -961,6 +961,7 @@ def test_tox_add_env_config_valid(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     env_conf = Config.make(
@@ -1022,6 +1023,7 @@ def test_tox_add_env_config_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     env_conf = Config.make(
@@ -1078,6 +1080,7 @@ def test_tox_add_env_config_no_base_python(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     env_conf = Config.make(
@@ -1164,6 +1167,7 @@ def test_add_ansible_matrix_pyproject(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -1215,6 +1219,7 @@ def test_add_ansible_matrix_ini_fallback(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -1335,6 +1340,7 @@ def _make_state(
         root_dir=config_file.parent,
         ansible=True,
         coverage=coverage,
+    result_json=None,
     )
     output = io.BytesIO()
     wrapper = io.TextIOWrapper(output, encoding="utf-8", line_buffering=True)
@@ -1418,7 +1424,7 @@ def test_collection_install_path(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=config_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1450,7 +1456,7 @@ def test_write_coverage_config(tmp_path: Path) -> None:
     config_file.touch()
     source = discover_source(config_file, None)
     env_conf = Config.make(
-        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -1494,7 +1500,7 @@ def test_write_coverage_config_isolates_data_by_environment(tmp_path: Path) -> N
     config_file.touch()
     source = discover_source(config_file, None)
     config = Config.make(
-        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path / ".tox", override=[], config_file=config_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -114,7 +114,7 @@ def test_conf_commands_molecule_via_conf_commands(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -156,7 +156,7 @@ def test_commands_pre_molecule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -205,7 +205,7 @@ def test_commands_pre_molecule_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path),
+        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -379,6 +379,7 @@ def test_add_ansible_matrix_molecule_pyproject_bool_true(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -422,6 +423,7 @@ def test_add_ansible_matrix_molecule_auto_found(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -466,6 +468,7 @@ def test_add_ansible_matrix_molecule_auto_not_found(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -509,6 +512,7 @@ def test_add_ansible_matrix_molecule_ini_true_case_insensitive(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -551,6 +555,7 @@ def test_tox_add_env_config_molecule_loads_append(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     env_conf = Config.make(
@@ -611,6 +616,7 @@ def test_add_ansible_matrix_molecule_pyproject_true(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -657,6 +663,7 @@ def test_add_ansible_matrix_molecule_pyproject_false(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()
@@ -730,6 +737,7 @@ def test_add_ansible_matrix_strips_integration_without_tests(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
+    result_json=None,
     )
 
     output = io.BytesIO()

--- a/tests/unit/test_plugin_molecule.py
+++ b/tests/unit/test_plugin_molecule.py
@@ -114,7 +114,13 @@ def test_conf_commands_molecule_via_conf_commands(tmp_path: Path) -> None:
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -156,7 +162,13 @@ def test_commands_pre_molecule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -205,7 +217,13 @@ def test_commands_pre_molecule_with_requirements(
     source = discover_source(ini_file, None)
 
     conf = Config.make(
-        Parsed(work_dir=tmp_path, override=[], config_file=ini_file, root_dir=tmp_path, result_json=None),
+        Parsed(
+            work_dir=tmp_path,
+            override=[],
+            config_file=ini_file,
+            root_dir=tmp_path,
+            result_json=None,
+        ),
         pos_args=[],
         source=source,
         extra_envs=[],
@@ -379,7 +397,7 @@ def test_add_ansible_matrix_molecule_pyproject_bool_true(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -423,7 +441,7 @@ def test_add_ansible_matrix_molecule_auto_found(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -468,7 +486,7 @@ def test_add_ansible_matrix_molecule_auto_not_found(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -512,7 +530,7 @@ def test_add_ansible_matrix_molecule_ini_true_case_insensitive(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -555,7 +573,7 @@ def test_tox_add_env_config_molecule_loads_append(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     env_conf = Config.make(
@@ -616,7 +634,7 @@ def test_add_ansible_matrix_molecule_pyproject_true(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -663,7 +681,7 @@ def test_add_ansible_matrix_molecule_pyproject_false(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()
@@ -737,7 +755,7 @@ def test_add_ansible_matrix_strips_integration_without_tests(
         config_file=ini_file,
         root_dir=tmp_path,
         ansible=True,
-    result_json=None,
+        result_json=None,
     )
 
     output = io.BytesIO()


### PR DESCRIPTION
## Summary

- tox 4.59.0 ([tox-dev/tox#4014](https://github.com/tox-dev/tox/pull/4014)) changed `State.__init__` in `tox/session/state.py` to access `options.parsed.result_json` directly instead of using `getattr` with a fallback default.
- This breaks 28 tests in the devel CI that construct `Parsed()` objects without including `result_json`, causing `AttributeError: 'Parsed' object has no attribute 'result_json'`.
- Adding `result_json=None` to all `Parsed()` constructor calls across 3 test files fixes the failures.

## Files changed

- `tests/unit/test_downstream_matrix.py` (1 call)
- `tests/unit/test_plugin.py` (26 calls)
- `tests/unit/test_plugin_molecule.py` (11 calls)

## Test plan

- [ ] Verify devel CI passes (the 28 previously failing tests should now pass)
- [ ] Verify stable CI still passes (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include the newly required parsed-result state.
  * Preserved existing test behavior and assertions across downstream, plugin, and molecule test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->