### PR TITLE
chore: Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Reporting a security vulnerability
+
+All security vulnerability reports MUST be submitted by email to:
+[security@ansible.com](mailto:security@ansible.com)
+
+Security vulnerabilities MUST NOT be reported through public channels such as
+GitHub issues, pull requests, the Ansible Forum, or social media.
+
+## What to include
+
+When submitting a vulnerability report, include the following:
+
+- **Title** (required): Clear, concise, descriptive summary.
+- **Impacted project** (required): Ideally a link to the GitHub project.
+- **Reporter details** (optional): Your name or handle and affiliation.
+- **Vulnerability description** (required): Technical details of the issue.
+- **Affected versions** (required): Known affected version(s), and ideally all
+  affected versions.
+- **Reproduction steps** (required): Minimal example to reproduce the issue.
+- **Impact assessment** (required): Potential exploit scenarios and severity.
+- **Suggested fix** (optional): Proposed remediation, if any.
+- **Disclosure status** (required): Whether this has been shared with other
+  parties or published and your plan for future sharing (e.g., at a conference).
+
+## Timeline
+
+- The Ansible Security Team aims to confirm receipt of vulnerability reports
+  within one (1) business day.
+- Our goal is to assess the report, coordinate fix and disclosure as quickly as
+  possible.
+- All confirmed vulnerabilities are addressed according to severity and impact.
+
+## Backports
+
+Generally, only the latest release of this project receives security updates.
+Earlier versions may receive critical fixes on a best-effort basis.
+
+## Ansible Security Policy
+
+For the complete Ansible Security Policy, including what qualifies as a
+reportable vulnerability, severity classification, the response process,
+coordinated disclosure, and the vulnerability management process, see
+[ansible.com/security](https://ansible.com/security).
+
+## EU Cyber Resilience Act: Open-Source Steward Statement
+
+This project is stewarded by **Red Hat, Inc.**, an open-source software steward
+as defined in Article 3(14) of the
+[EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
+
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)


### PR DESCRIPTION
This commit adds a security policy file that outlines how to report security vulnerabilities for tox-ansible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining how to report vulnerabilities privately.
  * Documented required report details, response timelines, backport practices, and applicable security policy references.
  * Included an open-source steward statement for EU Cyber Resilience Act compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->